### PR TITLE
Track binding info

### DIFF
--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -76,15 +76,15 @@ mainWithOptions opts =
       void $ execExpand initializeKernel ctx
       repl ctx initialWorld
     Repl (ReplOptions (Just file)) -> do
-      (_mn, ctx, theWorld, _bindings) <- expandFile file
-      repl ctx theWorld
+      (_mn, ctx, result) <- expandFile file
+      repl ctx (view expanderWorld result)
     Run (RunOptions file showWorld dumpBindings) -> do
-      (mn, _ctx, theWorld, theBindings) <- expandFile file
+      (mn, _ctx, result) <- expandFile file
       when showWorld $
-        prettyPrint theWorld
-      when dumpBindings $ do
-        prettyPrint theBindings
-      case Map.lookup mn (view worldEvaluated theWorld) of
+        prettyPrint $ view expanderWorld result
+      when dumpBindings $
+        prettyPrint $ view expanderBindingTable result
+      case Map.lookup mn (view worldEvaluated (view expanderWorld result)) of
         Nothing -> fail "Internal error: module not evaluated"
         Just results -> do
           -- Show just the results of evaluation in the module the user
@@ -102,7 +102,7 @@ mainWithOptions opts =
           case st of
             Left err -> prettyPrintLn err *> fail ""
             Right result ->
-              pure (mn, ctx, view expanderWorld result, view expanderBindingTable result)
+              pure (mn, ctx, result)
 
 
 tryCommand :: IORef (World Value) -> T.Text -> (T.Text -> IO ()) -> IO ()

--- a/src/Binding.hs
+++ b/src/Binding.hs
@@ -9,7 +9,9 @@ import ScopeSet
 import Data.Text (Text)
 import Data.Unique
 
+import Binding.Info
 import Phase
+import Syntax.SrcLoc
 
 newtype Binding = Binding Unique
   deriving (Eq, Ord)
@@ -17,7 +19,7 @@ newtype Binding = Binding Unique
 instance Show Binding where
   show (Binding b) = "(Binding " ++ show (hashUnique b) ++ ")"
 
-newtype BindingTable = BindingTable { _bindings :: Map Text [(ScopeSet, Binding)] }
+newtype BindingTable = BindingTable { _bindings :: Map Text [(ScopeSet, Binding, BindingInfo SrcLoc)] }
   deriving Show
 makeLenses ''BindingTable
 
@@ -31,7 +33,7 @@ instance Phased BindingTable where
   shift i = over bindings (Map.map (map (over _1 (shift i))))
 
 type instance Index BindingTable = Text
-type instance IxValue BindingTable = [(ScopeSet, Binding)]
+type instance IxValue BindingTable = [(ScopeSet, Binding, BindingInfo SrcLoc)]
 
 instance Ixed BindingTable where
   ix x f (BindingTable bs) = BindingTable <$> ix x f bs

--- a/src/Binding/Info.hs
+++ b/src/Binding/Info.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DeriveFunctor #-}
+module Binding.Info where
+
+import ShortShow
+
+data BindingInfo loc
+  = BoundLocally loc
+  | Defined loc
+  -- TODO add the binding info of the exported name to Imported, to
+  -- enable go to definition
+  | Imported loc
+  deriving (Eq, Functor, Show)
+
+instance ShortShow loc => ShortShow (BindingInfo loc) where
+  shortShow (BoundLocally l) = "BoundLocally " ++ shortShow l
+  shortShow (Defined l) = "Defined " ++ shortShow l
+  shortShow (Imported l) = "Imported " ++ shortShow l

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -26,6 +26,7 @@ module Expander (
   , expandEval
   , ExpansionErr(..)
   , ExpanderContext
+  , expanderBindingTable
   , expanderWorld
   , getState
   , addRootScope
@@ -47,6 +48,7 @@ import Data.Unique
 import System.Directory
 
 import Binding
+import Binding.Info
 import Control.Lens.IORef
 import Core
 import Env (Env)
@@ -64,6 +66,7 @@ import ScopeSet (ScopeSet)
 import Signals
 import SplitCore
 import Syntax
+import Syntax.SrcLoc
 import Value
 import World
 import qualified ScopeSet
@@ -86,7 +89,7 @@ initializeLanguage (Stx scs loc lang) = do
     addModuleBinding p n b =
       inPhase p $ do
         ident <- addModuleScope =<< addRootScope' (Stx scs loc n)
-        addBinding ident b
+        addImportBinding ident b
 
 
 expandModule :: ModuleName -> ParsedModule Syntax -> Expand CompleteModule
@@ -221,10 +224,23 @@ expandEval evalAction = do
 bindingTable :: Expand BindingTable
 bindingTable = view expanderBindingTable <$> getState
 
-addBinding :: Ident -> Binding -> Expand ()
-addBinding (Stx scs _ name) b = do
+addBinding :: Ident -> Binding -> BindingInfo SrcLoc -> Expand ()
+addBinding (Stx scs _ name) b info = do
   modifyState $ over (expanderBindingTable . at name) $
-    (Just . ((scs, b) :) . fromMaybe [])
+    (Just . ((scs, b, info) :) . fromMaybe [])
+
+addImportBinding :: Ident -> Binding -> Expand ()
+addImportBinding x@(Stx _ loc _) b =
+  addBinding x b (Imported loc)
+
+addDefinedBinding :: Ident -> Binding -> Expand ()
+addDefinedBinding x@(Stx _ loc _) b =
+  addBinding x b (Defined loc)
+
+addLocalBinding :: Ident -> Binding -> Expand ()
+addLocalBinding x@(Stx _ loc _) b =
+  addBinding x b (BoundLocally loc)
+
 
 bind :: Binding -> EValue -> Expand ()
 bind b v =
@@ -241,7 +257,7 @@ allMatchingBindings x scs = do
   let namesMatch = view (at x . non []) allBindings
   let scopesMatch =
         [ (scopes, b)
-        | (scopes, b) <- namesMatch
+        | (scopes, b, _) <- namesMatch
         , ScopeSet.isSubsetOf p scopes scs
         ]
   return scopesMatch
@@ -318,7 +334,7 @@ initializeKernel = do
             Stx _ _ (_, varStx, expr) <- mustBeVec stx
             x <- flip (addScope p) sc <$> mustBeIdent varStx
             b <- freshBinding
-            addBinding x b
+            addDefinedBinding x b
             var <- freshVar
             exprDest <- liftIO $ newSplitCorePtr
             bind b (EIncompleteDefn var x exprDest)
@@ -335,7 +351,7 @@ initializeKernel = do
               Stx _ _ (mname, mdef) <- mustBeVec def
               theName <- flip addScope' sc <$> mustBeIdent mname
               b <- freshBinding
-              addBinding theName b
+              addDefinedBinding theName b
               macroDest <- inEarlierPhase $ do
                 psc <- phaseRoot
                 schedule (addScope p (addScope (prior p) mdef psc) sc)
@@ -361,7 +377,7 @@ initializeKernel = do
             modExports <- getImports spec
             flip forExports_ modExports $ \p x b -> inPhase p do
               imported <- addRootScope' $ addScope' (Stx scs loc x) sc
-              addBinding imported b
+              addImportBinding imported b
             linkDecl dest (Import spec)
             nowValidAt pdest AllPhases
         )
@@ -554,7 +570,7 @@ initializeKernel = do
             -- phase) from being able to refer to the macro itself.
             let m' = addScope' m sc
             b <- freshBinding
-            addBinding m' b
+            addLocalBinding m' b
             macroDest <- inEarlierPhase $ do
               psc <- phaseRoot
               schedule (addScope (prior p) mdef psc)
@@ -604,7 +620,7 @@ initializeKernel = do
       psc <- phaseRoot
       let x' = addScope' (addScope p x sc) psc
       b <- freshBinding
-      addBinding x' b
+      addLocalBinding x' b
       var <- freshVar
       bind b (EVarMacro var)
       return (sc, x', var)

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -150,7 +150,7 @@ signalNum = toSignal <$> takeWhile1P (Just "signal (digits)") isDigit
     toSignal = Signal . read . T.unpack
 
 lexeme :: Parser a -> Parser (Located a)
-lexeme = located . L.lexeme eatWhitespace
+lexeme p = located p <* eatWhitespace
 
 located :: Parser a -> Parser (Located a)
 located p =


### PR DESCRIPTION
When an identifier is attached to a binding, track whether it's a
local binding, top-level definintion, or import, and save that
information.

There's also a command-line flag to view it.