### PR TITLE
Add special reader syntax for quotation

### DIFF
--- a/examples/quasiquote-syntax-test.kl
+++ b/examples/quasiquote-syntax-test.kl
@@ -1,0 +1,18 @@
+#lang "n-ary-app.kl"
+
+[import "quasiquote.kl"]
+
+[define thing 'nothing]
+
+[example thing]
+[example `thing]
+[example `,thing]
+
+[example `[thing]]
+[example `[,thing]]
+
+[example `[vec-syntax [,thing thing] thing]]
+
+[example `[vec-syntax [,thing thing ()] thing]]
+
+[example `(thing ,thing thing)]


### PR DESCRIPTION
This is in the broad Lisp tradition. Basically, the parser just inserts calls to `quote`, `quasiquote`, or `unquote` when given the appropriate syntax afterwards.