### PR TITLE
Cleanup examples

### DIFF
--- a/examples/macro-def.kl
+++ b/examples/macro-def.kl
@@ -1,5 +1,0 @@
-#lang kernel
-
-[define-macros ([id [lambda [stx] [pure [quote [lambda [x] x]]]]])]
-
-[example id]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -223,6 +223,14 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
         [ ( "examples/small.kl"
           , \m -> isEmpty (view moduleBody m)
           )
+        , ( "examples/two-defs.kl"
+          , \m ->
+              view moduleBody m & map (view completeDecl) &
+              filter (\case {(Define {}) -> True; _ -> False}) &
+              \case
+                [Define {}, Define {}] -> pure ()
+                _ -> assertFailure "Expected two definitions"
+          )
         , ( "examples/id-compare.kl"
           , \m ->
               view moduleBody m & map (view completeDecl) &


### PR DESCRIPTION
`macro-def.kl` is rejected, I guess the syntax must have changed since it was written.

`two-defs.kl` is accepted, but wasn't listed in the test suite.