### PR TITLE
Add macros in declaration positions

### DIFF
--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -1,0 +1,30 @@
+#lang "n-ary-app.kl"
+[import [shift "n-ary-app.kl" 1]]
+[import [shift "quasiquote.kl" 1]]
+
+[define fix
+  [lambda (fun)
+    ([lambda (rec) (fun [lambda (x) (rec rec x)])]
+     [lambda (rec) (fun [lambda (x) (rec rec x)])])]]
+
+[define-macros
+  ([defun
+    [lambda (stx)
+      (syntax-case stx
+        [[vec [_ f args body]]
+         [pure `[define ,f (fix [lambda (,f) [lambda ,args ,body]])]]]
+        [_ (syntax-error '"bad syntax" stx)])]])]
+
+[defun const (x y) x]
+
+[example (const 'a 'b)]
+
+[defun last-stx (stx)
+  (syntax-case stx
+    [[cons a d]
+     (syntax-case d
+       [() a]
+       [_ (last-stx d)])]
+    [_ stx])]
+
+[example (last-stx '(a b c d e f g))]

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -17,18 +17,23 @@ import SplitCore
 import Syntax
 import Value
 
+data MacroDest
+  = ExprDest SplitCorePtr
+  | DeclDest DeclPtr Scope DeclValidityPtr
+  deriving Show
+
 data ExpanderTask
-  = ExpandSyntax SplitCorePtr Syntax
-  | AwaitingSignal SplitCorePtr Signal [Closure]
-  | AwaitingMacro SplitCorePtr TaskAwaitMacro
+  = ExpandSyntax MacroDest Syntax
+  | AwaitingSignal MacroDest Signal [Closure]
+  | AwaitingMacro MacroDest TaskAwaitMacro
   | AwaitingDefn Var Ident Binding SplitCorePtr SplitCorePtr Syntax
     -- ^ Waiting on var, binding, and definiens, destination, syntax to expand
   | ExpandDecl DeclPtr Scope Syntax DeclValidityPtr
     -- ^ Where to put it, the scope, the decl, where to put the phase
   | ExpandMoreDecls ModBodyPtr Scope Syntax DeclValidityPtr
     -- Depends on the binding of the name(s) from the decl and the phase
-  | InterpretMacroAction SplitCorePtr MacroAction [Closure]
-  | ContinueMacroAction SplitCorePtr Value [Closure]
+  | InterpretMacroAction MacroDest MacroAction [Closure]
+  | ContinueMacroAction MacroDest Value [Closure]
   | EvalDefnAction Var Ident Phase SplitCorePtr
   deriving (Show)
 

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -359,7 +359,9 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
         , ( "examples/defun.kl"
           , \_m exampleVals ->
               case exampleVals of
-                [_, _] -> pure ()
+                [ValueSyntax (Syntax (Stx _ _ (Id "a"))), ValueSyntax (Syntax (Stx _ _ (Id "g")))] ->
+                  pure ()
+                [_, _] -> assertFailure $ "Wrong example values: " ++ show exampleVals
                 _ -> assertFailure "Wrong number of examples in file"
           )
         ]


### PR DESCRIPTION
This is illustrated by a function-definition macro that uses fix behind the scenes to implement recursive functions.

There are still no macros for module bodies yet.