### PR TITLE
Eliminate the square bracket/paren distinction

### DIFF
--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -1,6 +1,6 @@
 #lang "n-ary-app.kl"
 [import [shift "n-ary-app.kl" 1]]
-[import [shift "quasiquote.kl" 1]]
+
 
 [define fix
   [lambda (fun)
@@ -11,8 +11,8 @@
   ([defun
     [lambda (stx)
       (syntax-case stx
-        [[vec [_ f args body]]
-         [pure `[define ,f (fix [lambda (,f) [lambda ,args ,body]])]]]
+        [[list [_ f args body]]
+         (pure (list-syntax ('define f (list-syntax ('fix (list-syntax ('lambda (list-syntax (f) f) (list-syntax ('lambda args body) stx)) stx)) stx)) stx))]
         [_ (syntax-error '"bad syntax" stx)])]])]
 
 [defun const (x y) x]
@@ -28,3 +28,5 @@
     [_ stx])]
 
 [example (last-stx '(a b c d e f g))]
+
+[export defun]

--- a/examples/hygiene.kl
+++ b/examples/hygiene.kl
@@ -16,8 +16,8 @@
   ([should-not-capture
     [lambda (stx)
       (syntax-case stx
-        [[vec [_ body]]
-         [pure `[lambda (fun) ,body]]]
+        [[list [_ body]]
+         [pure `(lambda (fun) ,body)]]
         [_ (syntax-error '"bad syntax" stx)])]])]
 
 [example ([should-not-capture fun] [lambda (x y) x] 'a 'b)]

--- a/examples/id-compare.kl
+++ b/examples/id-compare.kl
@@ -7,7 +7,7 @@
 [define-macros
   ([thingp [lambda [stx]
              (syntax-case stx
-               [[vec [_ x]]
+               [[list [_ x]]
                 [>>= [free-identifier=? [quote thing] x]
                      [lambda [ok]
                        [if ok [pure [quote #true]] [pure [quote #false]]]]]])]])]

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -1,6 +1,6 @@
 #lang kernel
 
-[import [shift (only kernel cons-list-syntax lambda pure quote syntax-case vec-syntax export import) 1]]
+[import [shift (only kernel cons-list-syntax lambda pure quote syntax-case list-syntax export import) 1]]
 
 
 
@@ -18,23 +18,23 @@
                 [cons-list-syntax
                   [quote my-app]
                   [cons-list-syntax
-                    [vec-syntax [[quote #%app] fun arg0] stx]
+                    [list-syntax [[quote #%app] fun arg0] stx]
                     more-args
                     stx]
                   stx]]])])])]]
    [my-lam
     [lambda [stx]
      (syntax-case stx
-       [[vec [_ args body]]
+       [[list [_ args body]]
         (syntax-case args
           [() [pure body]]
           [[cons arg0 more-args]
-           [pure [vec-syntax [[quote lambda]
-                              [vec-syntax [arg0] arg0]
-                              [vec-syntax [[quote my-lam] more-args body] stx]]
-                          stx]]]
-          [[vec [arg]]
-           [pure [vec-syntax [[quote lambda] args body] stx]]])])]])]
+           [pure [list-syntax [[quote lambda]
+                               [list-syntax [arg0] arg0]
+                               [list-syntax [[quote my-lam] more-args body] stx]]
+                           stx]]]
+          [[list [arg]]
+           [pure [list-syntax [[quote lambda] args body] stx]]])])]])]
 
 [define-macros
   ([#%app
@@ -47,8 +47,8 @@
   ([lambda
     [lambda [stx]
      (syntax-case stx
-      [[vec [_ args body]]
-       [pure [vec-syntax [[quote my-lam] args body] stx]]])]])]
+      [[list [_ args body]]
+       [pure [list-syntax [[quote my-lam] args body] stx]]])]])]
 
 [define id [lambda (x) x]]
 
@@ -78,7 +78,7 @@
 [export if]
 [export syntax-error]
 [export syntax-case]
-[export vec-syntax]
+[export list-syntax]
 [export cons-list-syntax]
 [export empty-list-syntax]
 [export free-identifier=?]

--- a/examples/phase1.kl
+++ b/examples/phase1.kl
@@ -7,7 +7,7 @@
   [define m-impl
     [lambda [s]
       (syntax-case s
-        [[vec [_ e]] [pure e]])]]]
+        [[list [_ e]] [pure e]])]]]
 
 [define-macros ([m m-impl])]
 

--- a/examples/quasiquote-syntax-test.kl
+++ b/examples/quasiquote-syntax-test.kl
@@ -11,8 +11,8 @@
 [example `[thing]]
 [example `[,thing]]
 
-[example `[vec-syntax [,thing thing] thing]]
+[example `[list-syntax [,thing thing] thing]]
 
-[example `[vec-syntax [,thing thing ()] thing]]
+[example `[list-syntax [,thing thing ()] thing]]
 
 [example `(thing ,thing thing)]

--- a/examples/quasiquote.kl
+++ b/examples/quasiquote.kl
@@ -1,6 +1,16 @@
 #lang "n-ary-app.kl"
 
 [import [shift "n-ary-app.kl" 1]]
+[import [shift "defun.kl" 1]]
+
+
+(meta
+  (defun map-syntax (f stx)
+    (syntax-case stx
+      [() stx]
+      [(cons a d)
+       (cons-list-syntax (f a) (map-syntax f d) stx)]
+      [_ stx])))
 
 [define-macros
   ([unquote
@@ -9,91 +19,43 @@
    [quasiquote
     [lambda (stx)
       (syntax-case stx
-        [[vec [_ e]]
+        [[list [_ e]]
          (syntax-case e
            [[ident x]
-            [pure [vec-syntax [[quote quote] x] x]]]
+            [pure [list-syntax [[quote quote] x]
+                               x]]]
            [()
             [pure
-             [vec-syntax [[quote empty-list-syntax]
-                          [vec-syntax [[quote quote]
-                                       e]
-                                      [quote here]]]
+             [list-syntax [[quote empty-list-syntax]
+                           [list-syntax [[quote quote]
+                                        e]
+                                       'here]]
                          e]]]
-           [[cons a d]
-            [pure
-             [vec-syntax [[quote cons-list-syntax]
-                          [vec-syntax [[quote quasiquote] a] a]
-                          [vec-syntax [[quote quasiquote] d] d]
-                          [vec-syntax [[quote quote] e] e]]
-                         e]]]
-           [[vec [x]]
-            [pure
-             [vec-syntax [[quote vec-syntax]
-                          [vec-syntax [[vec-syntax [[quote quasiquote] x] e]]
-                                      [vec-syntax [[quote quote] stx] stx]]
-                          [vec-syntax [[quote quote] stx] stx]]
-                         stx]]]
-           [[vec [x y]]
+           [[cons x y]
             (syntax-case x
               [[ident i]
                [>>= [free-identifier=? i [quote unquote]]
                  [lambda [unquote?]
                    [if unquote?
-                       [pure y]
+                       (syntax-case y
+                         [[list [v]] [pure v]]
+                         [_ (syntax-error '"wrong number of arguments to unquote" e)])
                        [pure
-                        [vec-syntax [[quote vec-syntax]
-                                     [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                                  [vec-syntax [[quote quasiquote] y] e]]
-                                                 [vec-syntax [[quote quote] stx] stx]]
-                                     [vec-syntax [[quote quote] stx] stx]]
-                                    stx]]]]]]
+                        (list-syntax ('list-syntax
+                                        (map-syntax (lambda (s)
+                                                      (list-syntax ('quasiquote s)
+                                                                   s))
+                                                    e)
+                                        (list-syntax ('quote 'foo) 'foo))
+                                      e)]]]]]
               [_ [pure
-                  [vec-syntax [[quote vec-syntax]
-                               [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                            [vec-syntax [[quote quasiquote] y] e]]
-                                           [vec-syntax [[quote quote] stx] stx]]
-                               [vec-syntax [[quote quote] stx] stx]]
-                              stx]]])]
-           [[vec [x y z]]
-            [pure
-             [vec-syntax [[quote vec-syntax]
-                          [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                       [vec-syntax [[quote quasiquote] y] e]
-                                       [vec-syntax [[quote quasiquote] z] e]]
-                                      [vec-syntax [[quote quote] stx] stx]]
-                          [vec-syntax [[quote quote] stx] stx]] stx]]]
-           [[vec [x y z æ]]
-            [pure
-             [vec-syntax [[quote vec-syntax]
-                          [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                       [vec-syntax [[quote quasiquote] y] e]
-                                       [vec-syntax [[quote quasiquote] z] e]
-                                       [vec-syntax [[quote quasiquote] z] æ]]
-                                      [vec-syntax [[quote quote] stx] stx]]
-                          [vec-syntax [[quote quote] stx] stx]] stx]]]
-           [[vec [x y z æ ø]]
-            [pure
-             [vec-syntax [[quote vec-syntax]
-                          [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                       [vec-syntax [[quote quasiquote] y] e]
-                                       [vec-syntax [[quote quasiquote] z] e]
-                                       [vec-syntax [[quote quasiquote] z] æ]
-                                       [vec-syntax [[quote quasiquote] z] ø]]
-                                      [vec-syntax [[quote quote] stx] stx]]
-                          [vec-syntax [[quote quote] stx] stx]] stx]]]
-           [[vec [x y z æ ø å]]
-            [pure
-             [vec-syntax [[quote vec-syntax]
-                          [vec-syntax [[vec-syntax [[quote quasiquote] x] e]
-                                       [vec-syntax [[quote quasiquote] y] e]
-                                       [vec-syntax [[quote quasiquote] z] e]
-                                       [vec-syntax [[quote quasiquote] z] æ]
-                                       [vec-syntax [[quote quasiquote] z] ø]
-                                       [vec-syntax [[quote quasiquote] z] å]]
-                                      [vec-syntax [[quote quote] stx] stx]]
-                          [vec-syntax [[quote quote] stx] stx]] stx]]])]
-        [_ (syntax-error [vec-syntax [[quote "bad syntax"] stx] stx] stx)])]])]
+                  (list-syntax ('list-syntax
+                                  (map-syntax (lambda (s)
+                                                (list-syntax ('quasiquote s) s))
+                                              e)
+                                  (list-syntax ('quote 'foo) 'foo))
+                                e)]])])]
+        [_ (syntax-error [list-syntax [[quote "bad syntax"] stx] stx] stx)])]])]
 
 
 [define thing [quote nothing]]
@@ -105,9 +67,9 @@
 [example [quasiquote [thing]]]
 [example [quasiquote [[unquote thing]]]]
 
-[example [quasiquote [vec-syntax [[unquote thing] thing] thing]]]
+[example [quasiquote [list-syntax [[unquote thing] thing] thing]]]
 
-[example [quasiquote [vec-syntax [[unquote thing] thing ()] thing]]]
+[example [quasiquote [list-syntax [[unquote thing] thing ()] thing]]]
 
 [example [quasiquote (thing [unquote thing] thing)]]
 

--- a/klister.el
+++ b/klister.el
@@ -79,7 +79,7 @@
     "ident-syntax"
     "empty-list-syntax"
     "cons-list-syntax"
-    "vec-syntax"
+    "list-syntax"
     "syntax-case"
     "let-syntax"))
 

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -124,26 +124,27 @@ repl ctx startWorld = do
   forever $
     do putStr "> "
        l <- T.getLine
-       tryCommand theWorld l $ \l' -> case readExpr "<repl>" l' of
-         Left err -> T.putStrLn err
-         Right ok ->
-           do putStrLn "Parser output:"
-              T.putStrLn (syntaxText ok)
-              c <- execExpand (expandExpr ok) ctx
-              case c of
-                Left err -> putStr "Expander error: " *>
-                            prettyPrintLn err
-                Right (unsplit -> out) -> do
-                  putStrLn "Expander Output:"
-                  print out
-                  case runPartialCore out of
-                    Nothing -> putStrLn "Expression incomplete, can't evaluate"
-                    Just expr -> do
-                      putStrLn "Complete expression in core:"
-                      prettyPrint expr
-                      putStrLn ""
-                      currentWorld <- readIORef theWorld
-                      runExceptT (runReaderT (runEval (eval expr)) (phaseEnv runtime currentWorld)) >>=
-                        \case
-                          Left evalErr -> print evalErr
-                          Right val -> prettyPrint val >> putStrLn ""
+       tryCommand theWorld l $ \l' ->
+         case readExpr "<repl>" l' of
+           Left err -> T.putStrLn err
+           Right ok ->
+             do putStrLn "Parser output:"
+                T.putStrLn (syntaxText ok)
+                c <- execExpand (expandExpr ok) ctx
+                case c of
+                  Left err -> putStr "Expander error: " *>
+                              prettyPrintLn err
+                  Right (unsplit -> out) -> do
+                    putStrLn "Expander Output:"
+                    print out
+                    case runPartialCore out of
+                      Nothing -> putStrLn "Expression incomplete, can't evaluate"
+                      Just expr -> do
+                        putStrLn "Complete expression in core:"
+                        prettyPrint expr
+                        putStrLn ""
+                        currentWorld <- readIORef theWorld
+                        runExceptT (runReaderT (runEval (eval expr)) (phaseEnv runtime currentWorld)) >>=
+                          \case
+                            Left evalErr -> print evalErr
+                            Right val -> prettyPrint val >> putStrLn ""

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -39,7 +39,7 @@ data Pattern
   = PatternIdentifier Ident Var
   | PatternEmpty
   | PatternCons Ident Var Ident Var
-  | PatternVec [(Ident, Var)]
+  | PatternList [(Ident, Var)]
   | PatternAny
   deriving (Eq, Show)
 makePrisms ''Pattern
@@ -65,12 +65,12 @@ data ScopedCons core = ScopedCons
   deriving (Eq, Functor, Foldable, Show, Traversable)
 makeLenses ''ScopedCons
 
-data ScopedVec core = ScopedVec
-  { _scopedVecElements :: [core]
-  , _scopedVecScope    :: core
+data ScopedList core = ScopedList
+  { _scopedListElements :: [core]
+  , _scopedListScope    :: core
   }
   deriving (Eq, Functor, Foldable, Show, Traversable)
-makeLenses ''ScopedVec
+makeLenses ''ScopedList
 
 data HowEq = Free | Bound
   deriving (Eq, Show)
@@ -95,7 +95,7 @@ data CoreF core
   | CoreIdent (ScopedIdent core)
   | CoreEmpty (ScopedEmpty core)
   | CoreCons (ScopedCons core)
-  | CoreVec (ScopedVec core)
+  | CoreList (ScopedList core)
   deriving (Eq, Functor, Foldable, Show, Traversable)
 makePrisms ''CoreF
 
@@ -182,8 +182,8 @@ instance AlphaEq core => AlphaEq (CoreF core) where
   alphaCheck (CoreCons scopedCons1)
              (CoreCons scopedCons2) = do
     alphaCheck scopedCons1 scopedCons2
-  alphaCheck (CoreVec scopedVec1)
-             (CoreVec scopedVec2) = do
+  alphaCheck (CoreList scopedVec1)
+             (CoreList scopedVec2) = do
     alphaCheck scopedVec1 scopedVec2
   alphaCheck _ _ = notAlphaEquivalent
 
@@ -203,8 +203,8 @@ instance AlphaEq Pattern where
              (PatternCons _ x2 _ xs2) = do
     alphaCheck x1   x2
     alphaCheck xs1  xs2
-  alphaCheck (PatternVec xs1)
-             (PatternVec xs2) = do
+  alphaCheck (PatternList xs1)
+             (PatternList xs2) = do
     alphaCheck (map snd xs1) (map snd xs2)
   alphaCheck _ _ = notAlphaEquivalent
 
@@ -226,9 +226,9 @@ instance AlphaEq core => AlphaEq (ScopedCons core) where
     alphaCheck tl1    tl2
     alphaCheck scope1 scope2
 
-instance AlphaEq core => AlphaEq (ScopedVec core) where
-  alphaCheck (ScopedVec elements1 scope1)
-             (ScopedVec elements2 scope2) = do
+instance AlphaEq core => AlphaEq (ScopedList core) where
+  alphaCheck (ScopedList elements1 scope1)
+             (ScopedList elements2 scope2) = do
     alphaCheck elements1 elements2
     alphaCheck scope1    scope2
 
@@ -323,8 +323,8 @@ instance ShortShow core => ShortShow (CoreF core) where
     = "(Cons "
    ++ shortShow scopedCons
    ++ ")"
-  shortShow (CoreVec scopedVec)
-    = "(Vec "
+  shortShow (CoreList scopedVec)
+    = "(List "
    ++ shortShow scopedVec
    ++ ")"
 
@@ -340,8 +340,8 @@ instance ShortShow Pattern where
    ++ " "
    ++ shortShow xs
    ++ ")"
-  shortShow (PatternVec xs)
-    = "(Vec "
+  shortShow (PatternList xs)
+    = "(List "
    ++ shortShow (map snd xs)
    ++ ")"
   shortShow PatternAny = "_"
@@ -370,9 +370,9 @@ instance ShortShow core => ShortShow (ScopedCons core) where
    ++ shortShow scope
    ++ ")"
 
-instance ShortShow core => ShortShow (ScopedVec core) where
-  shortShow (ScopedVec elements scope)
-    = "(ScopedVec "
+instance ShortShow core => ShortShow (ScopedList core) where
+  shortShow (ScopedList elements scope)
+    = "(ScopedList "
    ++ shortShow elements
    ++ " "
    ++ shortShow scope

--- a/src/Env.hs
+++ b/src/Env.hs
@@ -2,15 +2,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
-module Env (Env, empty, insert, singleton, lookup, lookupIdent, lookupVal, toList) where
+module Env (Env, empty, insert, singleton, lookup, lookupIdent, lookupVal, toList, named) where
 
 import Prelude hiding (lookup)
 
 import Control.Lens
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Text (Text)
 
-import Syntax (Ident)
+import Syntax (Ident, Stx(..))
 
 newtype Env v a = Env (Map v (Ident, a))
   deriving (Eq, Functor, Monoid, Semigroup, Show)
@@ -35,6 +36,9 @@ lookupVal x env = snd <$> lookup x env
 
 lookupIdent :: Ord v => v -> Env v a -> Maybe Ident
 lookupIdent x env = fst <$> lookup x env
+
+named :: Text -> Env v a -> [(v, a)]
+named n (Env xs) = [(x, a) | (x, (Stx _ _ n', a)) <- Map.toList xs, n == n']
 
 type instance Index (Env v a) = v
 type instance IxValue (Env v a) = (Ident, a)

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -127,7 +127,7 @@ loadModuleFile modName =
          when (not existsp) $ throwError $ NoSuchFile $ show file
          stx <- liftIO (readModule file) >>=
                 \case
-                  Left err -> throwError $ InternalError $ show err -- TODO
+                  Left err -> throwError $ ReaderError err
                   Right stx -> return stx
          m <- expandModule modName stx
          es <- view expanderModuleExports <$> getState

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -5,6 +5,7 @@ module Expander.Error where
 import Control.Lens
 import Numeric.Natural
 import Data.Text (Text)
+import qualified Data.Text as T
 
 import Core
 import Evaluator
@@ -37,6 +38,7 @@ data ExpansionErr
   | InternalError String
   | NoSuchFile String
   | NotExported Ident Phase
+  | ReaderError Text
   deriving (Show)
 
 instance Pretty VarInfo ExpansionErr where
@@ -106,3 +108,5 @@ instance Pretty VarInfo ExpansionErr where
                           ]
   pp _env (InternalError str) =
     text "Internal error during expansion! This is a bug in the implementation." <> line <> string str
+  pp _env (ReaderError txt) =
+    vsep (map text (T.lines txt))

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -72,7 +72,7 @@ instance Pretty VarInfo ExpansionErr where
          ]
   pp env (NotRightLength len stx) =
     hang 2 $ group $
-    vsep [ text "Expected" <+> viaShow len <+> text "entries between square brackets, but got"
+    vsep [ text "Expected" <+> viaShow len <+> text "entries between parentheses, but got"
          , pp env stx
          ]
   pp env (NotVec stx) =

--- a/src/Expander/Syntax.hs
+++ b/src/Expander/Syntax.hs
@@ -43,35 +43,35 @@ mustBeModName (Syntax (Stx scs srcloc (Id "kernel"))) =
   return (Stx scs srcloc (KernelName kernelName))
 mustBeModName other = throwError (NotModName other)
 
-class MustBeVec a where
-  mustBeVec :: Syntax -> Expand (Stx a)
+class FixedLengthList a where
+  mustHaveEntries :: Syntax -> Expand (Stx a)
 
-instance MustBeVec () where
-  mustBeVec (Syntax (Stx scs srcloc (Vec []))) = return (Stx scs srcloc ())
-  mustBeVec other = throwError (NotRightLength 0 other)
+instance FixedLengthList () where
+  mustHaveEntries (Syntax (Stx scs srcloc (List []))) = return (Stx scs srcloc ())
+  mustHaveEntries other = throwError (NotRightLength 0 other)
 
-instance MustBeVec Syntax where
-  mustBeVec (Syntax (Stx scs srcloc (Vec [x]))) = return (Stx scs srcloc x)
-  mustBeVec other = throwError (NotRightLength 1 other)
+instance FixedLengthList Syntax where
+  mustHaveEntries (Syntax (Stx scs srcloc (List [x]))) = return (Stx scs srcloc x)
+  mustHaveEntries other = throwError (NotRightLength 1 other)
 
-instance MustBeVec (Syntax, Syntax) where
-  mustBeVec (Syntax (Stx scs srcloc (Vec [x, y]))) = return (Stx scs srcloc (x, y))
-  mustBeVec other = throwError (NotRightLength 2 other)
+instance FixedLengthList (Syntax, Syntax) where
+  mustHaveEntries (Syntax (Stx scs srcloc (List [x, y]))) = return (Stx scs srcloc (x, y))
+  mustHaveEntries other = throwError (NotRightLength 2 other)
 
-instance (a ~ Syntax, b ~ Syntax, c ~ Syntax) => MustBeVec (a, b, c) where
-  mustBeVec (Syntax (Stx scs srcloc (Vec [x, y, z]))) = return (Stx scs srcloc (x, y, z))
-  mustBeVec other = throwError (NotRightLength 3 other)
+instance (a ~ Syntax, b ~ Syntax, c ~ Syntax) => FixedLengthList (a, b, c) where
+  mustHaveEntries (Syntax (Stx scs srcloc (List [x, y, z]))) = return (Stx scs srcloc (x, y, z))
+  mustHaveEntries other = throwError (NotRightLength 3 other)
 
-instance MustBeVec (Syntax, Syntax, Syntax, Syntax) where
-  mustBeVec (Syntax (Stx scs srcloc (Vec [w, x, y, z]))) = return (Stx scs srcloc (w, x, y, z))
-  mustBeVec other = throwError (NotRightLength 4 other)
+instance FixedLengthList (Syntax, Syntax, Syntax, Syntax) where
+  mustHaveEntries (Syntax (Stx scs srcloc (List [w, x, y, z]))) = return (Stx scs srcloc (w, x, y, z))
+  mustHaveEntries other = throwError (NotRightLength 4 other)
 
-instance MustBeVec (Syntax, Syntax, Syntax, Syntax, Syntax) where
-  mustBeVec (Syntax (Stx scs srcloc (Vec [v, w, x, y, z]))) =
+instance FixedLengthList (Syntax, Syntax, Syntax, Syntax, Syntax) where
+  mustHaveEntries (Syntax (Stx scs srcloc (List [v, w, x, y, z]))) =
     return (Stx scs srcloc (v, w, x, y, z))
-  mustBeVec other = throwError (NotRightLength 5 other)
+  mustHaveEntries other = throwError (NotRightLength 5 other)
 
-instance MustBeVec [Syntax] where
-  mustBeVec (Syntax (Stx scs srcloc (Vec xs))) =
+instance FixedLengthList [Syntax] where
+  mustHaveEntries (Syntax (Stx scs srcloc (List xs))) =
     return (Stx scs srcloc xs)
-  mustBeVec other = throwError (NotVec other)
+  mustHaveEntries other = throwError (NotList other)

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -127,7 +127,7 @@ instance Pretty VarInfo core => Pretty VarInfo (CoreF core) where
   pp env (CoreIdent x) = pp env x
   pp env (CoreEmpty e) = pp env e
   pp env (CoreCons e) = pp env e
-  pp env (CoreVec e) = pp env e
+  pp env (CoreList e) = pp env e
 
 instance Pretty VarInfo core => Pretty VarInfo (SyntaxError core) where
   pp env err =
@@ -149,7 +149,7 @@ instance PrettyBinder VarInfo Pattern where
              annotate (BindingSite va) (text xa) <+>
              annotate (BindingSite vd) (text xd)),
      Env.insert vd idd () $ Env.singleton va ida ())
-  ppBind _env (PatternVec vars) =
+  ppBind _env (PatternList vars) =
     (vec $
      hsep [annotate (BindingSite v) (text x)
           | (Stx _ _ x, v) <- vars
@@ -174,10 +174,10 @@ instance Pretty VarInfo core => Pretty VarInfo (ScopedCons core) where
             pp env (view scopedConsTail pair)) <>
     angles (pp env (view scopedConsScope pair))
 
-instance Pretty VarInfo core => Pretty VarInfo (ScopedVec core) where
+instance Pretty VarInfo core => Pretty VarInfo (ScopedList core) where
   pp env xs =
-    vec (hsep $ map (pp env) (view scopedVecElements xs)) <>
-    angles (pp env (view scopedVecScope xs))
+    vec (hsep $ map (pp env) (view scopedListElements xs)) <>
+    angles (pp env (view scopedListScope xs))
 
 instance PrettyBinder VarInfo CompleteDecl where
   ppBind env (CompleteDecl d) = ppBind env d
@@ -267,7 +267,6 @@ instance Pretty VarInfo (ExprF Syntax) where
   pp _   (Sig s)    = viaShow s
   pp _   (Bool b)   = text $ if b then "#true" else "#false"
   pp env (List xs)  = parens (group (vsep (map (pp env . syntaxE) xs)))
-  pp env (Vec xs)   = brackets (group (vsep (map (pp env . syntaxE) xs)))
 
 instance Pretty VarInfo Closure where
   pp _ _ = text "#<closure>"

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -32,7 +32,6 @@ data ExprF a
   | Sig Signal
   | Bool Bool
   | List [a]
-  | Vec [a]
   deriving (Eq, Functor, Show)
 makePrisms ''ExprF
 
@@ -75,7 +74,6 @@ instance HasScopes Syntax where
       mapRec (Sig s) = Sig s
       mapRec (Bool b) = Bool b
       mapRec (List xs) = List $ map (\stx -> mapScopes f stx) xs
-      mapRec (Vec xs) = Vec $ map (\stx -> mapScopes f stx) xs
 
 instance Phased (Stx Text) where
   shift i = mapScopes (shift i)
@@ -112,10 +110,6 @@ syntaxText (Syntax (Stx _ _ e)) = go e
     go (Sig s) = T.pack (show s)
     go (Bool b) = if b then "#true" else "#false"
     go (List xs) = "(" <> T.intercalate " " (map syntaxText xs) <> ")"
-    go (Vec xs) = "[" <> T.intercalate " " (map syntaxText xs) <> "]"
-
-
-
 
 instance AlphaEq a => AlphaEq (Stx a) where
   alphaCheck (Stx scopeSet1 srcLoc1 x1)
@@ -130,9 +124,6 @@ instance AlphaEq a => AlphaEq (ExprF a) where
     alphaCheck x1 x2
   alphaCheck (List xs1)
              (List xs2) = do
-    alphaCheck xs1 xs2
-  alphaCheck (Vec xs1)
-             (Vec xs2) = do
     alphaCheck xs1 xs2
   alphaCheck _ _ = notAlphaEquivalent
 
@@ -150,7 +141,6 @@ instance ShortShow a => ShortShow (ExprF a) where
   shortShow (String s) = show s
   shortShow (Bool b) = if b then "#true" else "#false"
   shortShow (List xs) = shortShow xs
-  shortShow (Vec xs) = shortShow xs
   shortShow (Sig s) = shortShow s
 
 instance ShortShow Syntax where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,5 @@
-resolver: lts-13.26
+resolver: lts-14.8
 packages:
 - .
-allow-newer: true
-extra-deps:
- - tasty-hedgehog-1.0.0.1@sha256:cdcf60a29195bd0d819d3018c11db2e0deb7c6e559ad940c49409a5a7a982f83,1766
+
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
 resolver: lts-13.26
 packages:
 - .
-extra-deps: []
+allow-newer: true
+extra-deps:
+ - tasty-hedgehog-1.0.0.1@sha256:cdcf60a29195bd0d819d3018c11db2e0deb7c6e559ad940c49409a5a7a982f83,1766


### PR DESCRIPTION
This PR fixes #15 by doing the following:
1. The semantic distinction between parens and square brackets is removed. Now, as in Racket, they are synonymous, though square brackets and parens must still be paired with like delimiters (so `[)` is a parse error)
2. All instances of `vec` are renamed to `list` in operator names
3. The examples are rewritten to take into account the lack of fixed-width patterns. In particular, quasiquotation became much simpler.

While reworking the examples, bugs were encountered. This PR thus also fixes:
1. `free-identifier=?` returns false when one or both of its arguments have an ambiguous binding instead of throwing an ambiguous binding error. Otherwise, quasiquotation would crash on quotations that are ambiguous when comparing an identifier to `unquote`. Ambiguous quotations are useful when the ambiguous identifier occurs in a binding position, for instance.
2. Recursive loading of shifted modules did not shift the values of recursively-loaded modules. In other words, if module A loads B shifted by 1, and B loads C shifted by 1, then C should be shifted by 2. This was not happening, but now it is.
3. The Stack configuration did not allow loading `tasty-hedgehog` because Stackage didn't  have it in the chosen snapshot. Updating the snapshot fixed this so the tests could run with `stack` as well as `cabal-install`.