### PR TITLE
Export specs

### DIFF
--- a/examples/fun-exports-test.kl
+++ b/examples/fun-exports-test.kl
@@ -1,0 +1,8 @@
+#lang "n-ary-app.kl"
+(import (shift "n-ary-app.kl" 1))
+(import (shift "n-ary-app.kl" 2))
+(import "fun-exports.kl")
+
+(example a)
+(meta (example b))
+(meta (meta (example the-a)))

--- a/examples/fun-exports.kl
+++ b/examples/fun-exports.kl
@@ -1,0 +1,29 @@
+#lang kernel
+(import (shift kernel 1))
+(import (shift kernel 2))
+(import (shift kernel 3))
+
+
+
+
+(meta (define a 2))
+
+(meta (meta (define a 3)))
+
+(meta (meta (meta (define a 4))))
+
+(define a 1)
+
+(define b a)
+(meta (define b a))
+(meta (meta (define b a)))
+(meta (meta (meta (define b a))))
+
+(example b)
+(meta (example b))
+(meta (meta (example b)))
+(meta (meta (meta (example b))))
+
+(export a)
+(export (rename ([a b]) (shift 1 a)))
+(export (shift 2 (prefix "the-" a)))

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -62,25 +62,10 @@
 [example (compose id id)]
 [example (compose id id id)]
 
-[meta [export import]]
-[export #%module]
-[export #%app]
-[export const]
-[export lambda]
-[export define]
-[export example]
-[export define-macros]
-[export quote]
-[export meta]
-[export import]
-[export >>=]
-[export pure]
-[export if]
-[export syntax-error]
-[export syntax-case]
-[export list-syntax]
-[export cons-list-syntax]
-[export empty-list-syntax]
-[export free-identifier=?]
-[export log]
-[export export]
+(export #%module #%app
+        const lambda define example define-macros quote meta if
+        import export
+        >>= pure syntax-error syntax-case
+        list-syntax cons-list-syntax empty-list-syntax
+        free-identifier=? bound-identifier=? log)
+

--- a/examples/quasiquote.kl
+++ b/examples/quasiquote.kl
@@ -73,5 +73,5 @@
 
 [example [quasiquote (thing [unquote thing] thing)]]
 
-[export quasiquote]
-[export unquote]
+[export quasiquote unquote]
+

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -83,7 +83,7 @@ mainWithOptions opts =
       when showWorld $
         prettyPrint $ view expanderWorld result
       when dumpBindings $
-        prettyPrint $ view expanderBindingTable result
+        prettyPrint $ view expanderGlobalBindingTable result
       case Map.lookup mn (view worldEvaluated (view expanderWorld result)) of
         Nothing -> fail "Internal error: module not evaluated"
         Just results -> do

--- a/src/Binding.hs
+++ b/src/Binding.hs
@@ -11,6 +11,7 @@ import Data.Unique
 
 import Binding.Info
 import Phase
+import ShortShow
 import Syntax.SrcLoc
 
 newtype Binding = Binding Unique
@@ -18,6 +19,9 @@ newtype Binding = Binding Unique
 
 instance Show Binding where
   show (Binding b) = "(Binding " ++ show (hashUnique b) ++ ")"
+
+instance ShortShow Binding where
+  shortShow (Binding b) = "b" ++ show (hashUnique b)
 
 newtype BindingTable = BindingTable { _bindings :: Map Text [(ScopeSet, Binding, BindingInfo SrcLoc)] }
   deriving Show

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -27,7 +27,8 @@ module Expander (
   , expandEval
   , ExpansionErr(..)
   , ExpanderContext
-  , expanderBindingTable
+  , expanderCurrentBindingTable
+  , expanderGlobalBindingTable
   , expanderWorld
   , getState
   , addRootScope
@@ -40,6 +41,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.Writer
 import Data.Foldable
+import Data.List (nub)
 import Data.List.Extra (maximumOn)
 import qualified Data.Map as Map
 import Data.Maybe
@@ -97,7 +99,9 @@ initializeLanguage (Stx scs loc lang) = do
 
 
 expandModule :: ModuleName -> ParsedModule Syntax -> Expand CompleteModule
-expandModule thisMod src =
+expandModule thisMod src = do
+  startBindings <- view expanderCurrentBindingTable <$> getState
+  modifyState $ set expanderCurrentBindingTable mempty
   local (set (expanderLocal . expanderModuleName) thisMod) do
     lang <- mustBeModName (view moduleLanguage src)
     initializeLanguage lang
@@ -113,7 +117,9 @@ expandModule thisMod src =
                            , _moduleBody = body
                            , _moduleExports = noExports
                            }
-    return $ Expanded theModule
+    bs <- view expanderCurrentBindingTable <$> getState
+    modifyState $ set expanderCurrentBindingTable startBindings
+    return $ Expanded theModule bs
 
 
 
@@ -145,7 +151,8 @@ getExports :: ExportSpec -> Expand Exports
 getExports (ExportIdents idents) = do
   p <- currentPhase
   bs <- for idents $ \x -> do
-    binding <- resolve x
+    x' <- addRootScope' x
+    binding <- resolve x'
     return (view stxValue x, binding)
   return $ foldr (uncurry $ addExport p) noExports bs
 getExports (ExportRenamed spec rens) = mapExportNames rename <$> getExports spec
@@ -155,7 +162,10 @@ getExports (ExportRenamed spec rens) = mapExportNames rename <$> getExports spec
         Nothing -> x
         Just y -> y
 getExports (ExportPrefixed spec pref) = mapExportNames (pref <>) <$> getExports spec
-getExports (ExportShifted spec i) = inEarlierPhase (getExports spec)
+getExports (ExportShifted spec i) = do
+  p <- currentPhase
+  inPhase (shift i p) $
+    getExports spec
 
 getImports :: ImportSpec -> Expand Exports
 getImports (ImportModule (Stx _ _ mn)) = visit mn
@@ -189,9 +199,9 @@ visit modName = do
          Just m -> do
            let es = maybe noExports id (view (worldExports . at modName) world)
            return (m, es)
-         Nothing -> do
-           (m, es) <- inPhase runtime $ loadModuleFile modName
-           return (m, es)
+         Nothing ->
+           inPhase runtime $
+             loadModuleFile modName
   p <- currentPhase
   let i = phaseNum p
   visitedp <- Set.member p .
@@ -203,7 +213,11 @@ visit modName = do
     modifyState $
       set (expanderWorld . worldEvaluated . at modName)
           (Just evalResults)
+    let bs = getModuleBindings m'
+    modifyState $ over expanderGlobalBindingTable $ (<> bs)
   return (shift i es)
+  where getModuleBindings (Expanded _ bs) = bs
+        getModuleBindings (KernelModule _) = mempty
 
 -- | Evaluate an expanded module at the current expansion phase,
 -- recursively loading its run-time dependencies.
@@ -212,7 +226,7 @@ evalMod (KernelModule _) =
   -- Builtins go here, suitably shifted. There are no built-in values
   -- yet, only built-in syntax, but this may change.
   return []
-evalMod (Expanded em) = snd <$> runWriterT (traverse_ evalDecl (view moduleBody em))
+evalMod (Expanded em _) = snd <$> runWriterT (traverse_ evalDecl (view moduleBody em))
   where
     evalDecl (CompleteDecl d) =
       case d of
@@ -287,12 +301,17 @@ expandEval evalAction = do
       throwError $ MacroEvaluationError p err
     Right val -> return val
 
-bindingTable :: Expand BindingTable
-bindingTable = view expanderBindingTable <$> getState
+visibleBindings :: Expand BindingTable
+visibleBindings = do
+  globals <- view expanderGlobalBindingTable <$> getState
+  locals <- view expanderCurrentBindingTable <$> getState
+  return (globals <> locals)
 
+
+-- | Add a binding to the current module's table
 addBinding :: Ident -> Binding -> BindingInfo SrcLoc -> Expand ()
 addBinding (Stx scs _ name) b info = do
-  modifyState $ over (expanderBindingTable . at name) $
+  modifyState $ over (expanderCurrentBindingTable . at name) $
     (Just . ((scs, b, info) :) . fromMaybe [])
 
 addImportBinding :: Ident -> Binding -> Expand ()
@@ -318,9 +337,8 @@ bind b v =
 
 allMatchingBindings :: Text -> ScopeSet -> Expand [(ScopeSet, Binding)]
 allMatchingBindings x scs = do
-  allBindings <- bindingTable
+  namesMatch <- view (at x . non []) <$> visibleBindings
   p <- currentPhase
-  let namesMatch = view (at x . non []) allBindings
   let scopesMatch =
         [ (scopes, b)
         | (scopes, b, _) <- namesMatch
@@ -334,7 +352,7 @@ checkUnambiguous :: ScopeSet -> [ScopeSet] -> Ident -> Expand ()
 checkUnambiguous best candidates blame =
   do p <- currentPhase
      let bestSize = ScopeSet.size p best
-     let candidateSizes = map (ScopeSet.size p) candidates
+     let candidateSizes = map (ScopeSet.size p) (nub candidates)
      if length (filter (== bestSize) candidateSizes) > 1
        then throwError (Ambiguous p blame candidates)
        else return ()
@@ -344,7 +362,8 @@ resolve stx@(Stx scs srcLoc x) = do
   p <- currentPhase
   bs <- allMatchingBindings x scs
   case bs of
-    [] -> throwError (Unknown (Stx scs srcLoc x))
+    [] ->
+      throwError (Unknown (Stx scs srcLoc x))
     candidates ->
       let best = maximumOn (ScopeSet.size p . fst) candidates
       in checkUnambiguous (fst best) (map fst candidates) stx *>
@@ -398,7 +417,7 @@ initializeKernel = do
         , \ sc dest pdest stx -> do
             p <- currentPhase
             Stx _ _ (_, varStx, expr) <- mustHaveEntries stx
-            x <- flip (addScope p) sc <$> mustBeIdent varStx
+            x <- flip addScope' sc <$> mustBeIdent varStx
             b <- freshBinding
             addDefinedBinding x b
             var <- freshVar
@@ -418,9 +437,7 @@ initializeKernel = do
               theName <- flip addScope' sc <$> mustBeIdent mname
               b <- freshBinding
               addDefinedBinding theName b
-              macroDest <- inEarlierPhase $ do
-                psc <- phaseRoot
-                schedule (addScope p (addScope (prior p) mdef psc) sc)
+              macroDest <- inEarlierPhase $ schedule (addScope p mdef sc)
               v <- freshMacroVar
               bind b $ EIncompleteMacro v theName macroDest
               return (theName, v, macroDest)
@@ -504,14 +521,14 @@ initializeKernel = do
         exportSpec blame elts
           | [Syntax (Stx scs' srcloc'  (List ((getIdent -> Just (Stx _ _ kw)) : args)))] <- elts =
               case kw of
-                "renaming" ->
+                "rename" ->
                   case args of
                     (rens : more) -> do
                       pairs <- getRenames rens
                       spec <- exportSpec blame more
                       return $ ExportRenamed spec pairs
                     _ -> throwError $ NotExportSpec blame
-                "prefixing" ->
+                "prefix" ->
                   case args of
                     ((syntaxE -> String pref) : more) -> do
                       spec <- exportSpec blame more
@@ -539,7 +556,6 @@ initializeKernel = do
                 Stx _ _ y' <- mustBeIdent y
                 pure (x', y')
             getRenames _ = throwError $ NotExportSpec blame
-        exportSpec blame _other = throwError $ NotExportSpec blame
 
     exprPrims :: [(Text, SplitCorePtr -> Syntax -> Expand ())]
     exprPrims =
@@ -663,9 +679,9 @@ initializeKernel = do
         )
       , ( "let-syntax"
         , \dest stx -> do
-            Stx _ _ (_ :: Syntax, macro, body) <- mustHaveEntries stx
+            Stx _ loc (_ :: Syntax, macro, body) <- mustHaveEntries stx
             Stx _ _ (mName, mdef) <- mustHaveEntries macro
-            sc <- freshScope
+            sc <- freshScope $ T.pack $ "Scope for let-syntax at " ++ shortShow loc
             m <- mustBeIdent mName
             p <- currentPhase
             -- Here, the binding occurrence of the macro gets the
@@ -729,7 +745,7 @@ initializeKernel = do
 
     prepareVar :: Syntax -> Expand (Scope, Ident, Var)
     prepareVar varStx = do
-      sc <- freshScope
+      sc <- freshScope $ T.pack $ "For variable " ++ shortShow varStx
       x <- mustBeIdent varStx
       p <- currentPhase
       psc <- phaseRoot
@@ -802,18 +818,19 @@ forkExpandDecls dest (Syntax (Stx _ _ (List []))) =
   modifyState $ over expanderCompletedModBody (<> Map.singleton dest Done)
 forkExpandDecls dest (Syntax (Stx scs loc (List (d:ds)))) = do
   -- Create a scope for this new declaration
-  sc <- freshScope
+  sc <- freshScope $ T.pack $ "For declaration at " ++ shortShow (stxLoc d)
   restDest <- liftIO $ newModBodyPtr
   declDest <- liftIO $ newDeclPtr
   declPhase <- newDeclValidityPtr
   modifyState $ over expanderCompletedModBody $
     (<> Map.singleton dest (Decl declDest restDest))
-  p <- currentPhase
   forkExpanderTask $
     ExpandMoreDecls restDest sc
-      (Syntax (Stx scs loc (List (map (flip (addScope p) sc) ds))))
+      (Syntax (Stx scs loc (List ds)))
       declPhase
   forkExpandOneDecl declDest sc declPhase =<< addRootScope d
+  where
+    stxLoc (Syntax (Stx _ srcloc _)) = srcloc
 forkExpandDecls _dest _other =
   error "TODO real error message - malformed module body"
 
@@ -947,7 +964,7 @@ runTask (tid, localData, task) = withLocal localData $ do
 expandOneExpression :: SplitCorePtr -> Syntax -> Expand ()
 expandOneExpression dest stx
   | Just ident <- identifierHeaded stx = do
-      b <- resolve ident
+      b <- resolve =<< addRootScope ident
       v <- getEValue b
       case v of
         EPrimMacro impl -> impl dest stx
@@ -967,7 +984,7 @@ expandOneExpression dest stx
         EIncompleteDefn x n d ->
           forkAwaitingDefn x n b d dest stx
         EUserMacro transformerName -> do
-          stepScope <- freshScope
+          stepScope <- freshScope $ T.pack $ "Expansion step for " ++ shortShow ident
           p <- currentPhase
           implV <- Env.lookupVal transformerName <$> currentTransformerEnv
           case implV of
@@ -1012,7 +1029,7 @@ addApp ctor (Syntax (Stx scs loc _)) args =
 expandOneDeclaration :: Scope -> DeclPtr -> Syntax -> DeclValidityPtr -> Expand ()
 expandOneDeclaration sc dest stx ph
   | Just ident <- identifierHeaded stx = do
-      b <- resolve ident
+      b <- resolve =<< addRootScope ident
       v <- getEValue b
       case v of
         EPrimMacro _ ->
@@ -1026,7 +1043,7 @@ expandOneDeclaration sc dest stx ph
         EIncompleteDefn _ _ _ ->
           throwError $ InternalError "Current context won't accept expressions"
         EUserMacro transformerName -> do
-          stepScope <- freshScope
+          stepScope <- freshScope $ T.pack $ "Expansion step for decl " ++ shortShow ident
           p <- currentPhase
           implV <- Env.lookupVal transformerName <$> currentTransformerEnv
           case implV of
@@ -1114,6 +1131,9 @@ interpretMacroAction (MacroActionIdentEq how v1 v2) = do
           -- Ambiguous bindings should not crash the comparison -
           -- they're just not free-identifier=?.
           Ambiguous _ _ _ -> return $ Right $ ValueBool $ False
+          -- Similarly, things that are not yet bound are just not
+          -- free-identifier=?
+          Unknown _ -> return $ Right $ ValueBool $ False
           e -> throwError e
     Bound ->
       return $ Right $ ValueBool $ view stxScopeSet id1 == view stxScopeSet id2

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -30,6 +30,7 @@ data ExpansionErr
   | NotRightLength Natural Syntax
   | NotVec Syntax
   | NotImportSpec Syntax
+  | NotExportSpec Syntax
   | UnknownPattern Syntax
   | MacroRaisedSyntaxError (SyntaxError Syntax)
   | MacroEvaluationError Phase EvalError
@@ -79,6 +80,8 @@ instance Pretty VarInfo ExpansionErr where
     hang 2 $ group $ vsep [text "Expected square-bracketed vec but got", pp env stx]
   pp env (NotImportSpec stx) =
     hang 2 $ group $ vsep [text "Expected import spec but got", pp env stx]
+  pp env (NotExportSpec stx) =
+    hang 2 $ group $ vsep [text "Expected export spec but got", pp env stx]
   pp env (UnknownPattern stx) =
     hang 2 $ group $ vsep [text "Unknown pattern",  pp env stx]
   pp env (MacroRaisedSyntaxError err) =

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -153,11 +153,11 @@ newtype CompleteDecl = CompleteDecl { _completeDecl :: Decl CompleteDecl Core }
 instance Phased CompleteDecl where
   shift i (CompleteDecl d) = CompleteDecl (shift i d)
 
-data CompleteModule = Expanded !(Module [] CompleteDecl) | KernelModule Phase
+data CompleteModule = Expanded !(Module [] CompleteDecl) !BindingTable | KernelModule !Phase
   deriving Show
 
 instance Phased CompleteModule where
-  shift i (Expanded m) = Expanded (shift i m)
+  shift i (Expanded m bs) = Expanded (shift i m) (shift i bs)
   shift i (KernelModule p) = KernelModule (shift i p)
 
 instance (Functor f, Phased a) => Phased (Module f a) where

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -14,6 +14,7 @@ module Module (
   , Imports
   , noImports
   , ImportSpec(..)
+  , ExportSpec(..)
   , Exports
   , getExport
   , addExport
@@ -129,6 +130,13 @@ filterExports ok (Exports es) =
       let out = Map.filterWithKey (\t _ -> ok p t) bs
       in if Map.null out then Nothing else Just out
 
+data ExportSpec
+  = ExportIdents [Ident]
+  | ExportRenamed ExportSpec [(Text, Text)]
+  | ExportPrefixed ExportSpec Text
+  | ExportShifted ExportSpec Natural
+  deriving Show
+
 data Module f a = Module
   { _moduleName :: ModuleName
   , _moduleImports :: !Imports
@@ -174,7 +182,7 @@ data Decl decl expr
   | Meta decl
   | Example expr
   | Import ImportSpec
-  | Export Ident
+  | Export ExportSpec
   deriving (Functor, Show)
 
 instance Bifunctor Decl where
@@ -183,7 +191,7 @@ instance Bifunctor Decl where
   bimap f _g (Meta d) = Meta (f d)
   bimap _f g (Example e) = Example (g e)
   bimap _f _g (Import spec) = Import spec
-  bimap _f _g (Export x) = Export x
+  bimap _f _g (Export spec) = Export spec
 
 instance (Phased decl, Phased expr) => Phased (Decl decl expr) where
   shift i = bimap (shift i) (shift i)

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -205,6 +205,30 @@ instance (PrettyBinder VarInfo a, Pretty VarInfo b) => PrettyBinder VarInfo (Dec
     (hang 4 $ text "export" <+> pp env x, mempty)
   ppBind env (Example e) = (hang 4 $ text "example" <+> group (pp env e), mempty)
 
+instance Pretty VarInfo ExportSpec where
+  pp env (ExportIdents ids) =
+    text "{" <> align (vsep [pp env x | (Stx _ _ x) <- ids]) <> text "}"
+  pp env (ExportRenamed spec rens) =
+    align $ hang 2 $ group $
+      pp env spec <> line <>
+      text "renaming" <+> text "{" <>
+      (align $ group $ vsep [text x <+> text "↦" <+> text y
+                            | (x, y) <- rens
+                            ]) <>
+      text "}"
+  pp env (ExportPrefixed spec p) =
+    align $ hang 2 $ group $
+    vsep [ text "(" <> align (group (pp env spec)) <> ")"
+         , text "with" <+> text "prefix"
+         , text p
+         ]
+  pp env (ExportShifted spec i) =
+    align $ hang 2 $ group $
+    vsep [ text "(" <> align (group (pp env spec)) <> ")"
+         , text "shifted" <+> text "by"
+         , viaShow i
+         ]
+
 instance Pretty VarInfo ImportSpec where
   pp env (ImportModule mn) = pp env mn
   pp env (ImportOnly spec ids) = group $ vsep [ text "only"

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -367,7 +367,7 @@ instance Pretty VarInfo a => Pretty VarInfo (Env MacroVar a) where
          ]
 
 instance Pretty VarInfo CompleteModule where
-  pp env (Expanded em) = pp env em
+  pp env (Expanded em _) = pp env em
   pp env (KernelModule p) = text "⟨kernel module" <> text "@" <> pp env p <> "⟩"
 
 instance Pretty VarInfo Binding where

--- a/src/Scope.hs
+++ b/src/Scope.hs
@@ -3,11 +3,10 @@ module Scope where
 
 import Control.Lens
 
+import Data.Text (Text)
 
 -- Int should be enough for now - consider bumping to something like int64
-newtype Scope = Scope Int
+data Scope = Scope { scopeNum :: Int, scopePurpose :: Text }
   deriving (Eq, Ord, Show)
-makePrisms ''Scope
+makeLenses ''Scope
 
-nextScope :: Scope -> Scope
-nextScope (Scope i) = Scope (i + 1)

--- a/src/ShortShow.hs
+++ b/src/ShortShow.hs
@@ -21,6 +21,16 @@ instance (ShortShow a, ShortShow b) => ShortShow (a, b) where
    ++ ", "
    ++ shortShow y
    ++ ")"
+instance (ShortShow a, ShortShow b, ShortShow c) => ShortShow (a, b, c) where
+  shortShow (x, y, z)
+    = "("
+   ++ shortShow x
+   ++ ", "
+   ++ shortShow y
+   ++ ", "
+   ++ shortShow z
+   ++ ")"
+
 instance ShortShow a => ShortShow [a] where
   shortShow xs
     = "["

--- a/src/World.hs
+++ b/src/World.hs
@@ -46,7 +46,5 @@ addExpandedModule m =
     Just m' -> Just m'
   where
     getName :: CompleteModule -> ModuleName
-    getName (Expanded em) = view moduleName em
+    getName (Expanded em _) = view moduleName em
     getName (KernelModule _) = KernelName kernelName
-
-

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -331,9 +331,9 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
                   case thingDef of
                     Core (CoreSyntax (Syntax (Stx _ _ (Id "nothing")))) ->
                       case examples of
-                        [e1, e2, e3, e4, e5, e6, e7, e8, Export _, Export _ ] -> do
+                        [e1, e2, e3, e4, e5, e6, e7, e8, Export _] -> do
                           testQuasiquoteExamples [e1, e2, e3, e4, e5, e6, e7, e8]
-                        other -> assertFailure ("Expected 8 examples and 2 exports: " ++ show other)
+                        other -> assertFailure ("Expected 8 examples and 1 export: " ++ show other)
                     other -> assertFailure ("Unexpected thing def " ++ show other)
                 _ -> assertFailure "Expected an import, two macros, a definition, and examples"
           )

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -68,7 +68,7 @@ operationTests :: TestTree
 operationTests =
   testGroup "Core operations"
   [ testCase "Shifting core expressions" $
-    let sc = Scope 42
+    let sc = Scope 42 "Test suite"
         scs = ScopeSet.insertAtPhase runtime sc ScopeSet.empty
         stx = Syntax (Stx scs fakeLoc (Id "hey"))
         expr = Core (CoreIf (Core (CoreBool True))
@@ -385,6 +385,27 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
                 [_, _] -> assertFailure $ "Wrong example values: " ++ show exampleVals
                 _ -> assertFailure "Wrong number of examples in file"
           )
+        , ( "examples/fun-exports.kl"
+          , \_m exampleVals ->
+              case exampleVals of
+                [ValueSignal a, ValueSignal b, ValueSignal c, ValueSignal d] -> do
+                  assertAlphaEq "First example is 1" a (Signal 1)
+                  assertAlphaEq "Second example is 2" b (Signal 2)
+                  assertAlphaEq "Third example is 3" c (Signal 3)
+                  assertAlphaEq "Fourth example is 4" d (Signal 4)
+                _ ->
+                  assertFailure "Expected four signals in example"
+          )
+        , ( "examples/fun-exports-test.kl"
+          , \_m exampleVals ->
+              case exampleVals of
+                [ValueSignal a, ValueSignal b, ValueSignal c] -> do
+                  assertAlphaEq "First example is 1" a (Signal 1)
+                  assertAlphaEq "Second example is 2" b (Signal 2)
+                  assertAlphaEq "Third example is 3" c (Signal 3)
+                _ ->
+                  assertFailure "Expected three signals in example"
+          )
         ]
       ]
     shouldn'tWork =
@@ -523,7 +544,7 @@ testFile f p = do
             assertFailure "No module found"
           Just (KernelModule _) ->
             assertFailure "Expected user module, got kernel"
-          Just (Expanded m) ->
+          Just (Expanded m _) ->
             case Map.lookup mn (view worldEvaluated w) of
               Nothing -> assertFailure "Module valuees not in its own expansion"
               Just evalResults ->
@@ -556,6 +577,9 @@ assertAlphaEq preface expected actual =
 -- TODO(lb): Should we be accessing size parameters from the Gen monad to decide
 -- these ranges?
 
+range16 :: Range.Range Int
+range16 = Range.linear 0 32
+
 range32 :: Range.Range Int
 range32 = Range.linear 0 32
 
@@ -572,7 +596,7 @@ genPhase =
   in more <$> Gen.int range256 <*> pure runtime
 
 genScope :: MonadGen m => m Scope
-genScope = Scope <$> Gen.int range1024
+genScope = Scope <$> Gen.int range1024 <*> Gen.text range16 Gen.lower
 
 genSetScope :: MonadGen m => m (Set Scope)
 genSetScope = Gen.set range32 genScope


### PR DESCRIPTION
This PR does the following:
1. A more informative syntax for exports, allowing things like renaming and exporting at phases other than 0
2. Fixes a number of bugs in scope addition that were exposed by checking number 1
3. Fix long-standing issues in binding tables and shifted macros that were masked by the bugs from step 2.

In particular, expanded modules now contain a binding table that can be shifted along with their contents.