### PR TITLE
WIP: Begin implementing type checker

### DIFF
--- a/examples/tiny-types.kl
+++ b/examples/tiny-types.kl
@@ -1,0 +1,11 @@
+#lang kernel
+
+(example (the Bool #true))
+(example (the Bool #false))
+(example (the Syntax 'foo))
+(example (the (Macro Syntax) (pure 'foo)))
+
+
+
+
+

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -40,6 +40,9 @@ data ExpansionErr
   | NoSuchFile String
   | NotExported Ident Phase
   | ReaderError Text
+  | NotValidType Syntax
+  | TypeMismatch String String -- TODO structured representation
+  | OccursCheckFailed
   deriving (Show)
 
 instance Pretty VarInfo ExpansionErr where
@@ -113,3 +116,5 @@ instance Pretty VarInfo ExpansionErr where
     text "Internal error during expansion! This is a bug in the implementation." <> line <> string str
   pp _env (ReaderError txt) =
     vsep (map text (T.lines txt))
+  pp env (NotValidType stx) =
+    hang 2 $ group $ vsep [text "Not a type:", pp env stx]

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ViewPatterns #-}
+module Expander.TC where
+
+import Control.Lens
+import Control.Monad.Except
+import Data.Foldable
+
+import Expander.Monad
+import Type
+
+
+derefType :: MetaPtr -> Expand (TVar Ty)
+derefType ptr =
+  (view (expanderTypeStore . at ptr) <$> getState) >>=
+  \case
+    Nothing -> throwError $ InternalError "Dangling type metavar"
+    Just var -> pure var
+
+
+setTVKind :: MetaPtr -> VarKind Ty -> Expand ()
+setTVKind ptr k = do
+  _ <- derefType ptr -- fail if not present
+  modifyState $ over (expanderTypeStore . at ptr) $ fmap (set varKind k)
+
+setTVLevel :: MetaPtr -> BindingLevel -> Expand ()
+setTVLevel ptr l = do
+  _ <- derefType ptr -- fail if not present
+  modifyState $ over (expanderTypeStore . at ptr) $ fmap (set varLevel l)
+
+normType :: Ty -> Expand Ty
+normType t@(unTy -> TMetaVar ptr) = do
+  tv <- derefType ptr
+  case view varKind tv of
+    Link found -> do
+      t' <- normType (Ty found)
+      setTVKind ptr (Link (unTy t'))
+      return t'
+    _ -> return t
+normType t = return t
+
+metas :: Ty -> Expand [MetaPtr]
+metas t =
+  normType t >>=
+  \case
+    Ty (TMetaVar x) -> pure [x]
+    Ty (TFun a b) -> (++) <$> metas a <*> metas b
+    Ty (TMacro a) -> metas a
+    Ty (TList a) -> metas a
+    _ -> pure []
+
+occursCheck :: MetaPtr -> Ty -> Expand ()
+occursCheck ptr t = do
+  free <- metas t
+  if ptr `elem` free
+    then throwError $ OccursCheckFailed
+    else pure ()
+
+pruneLevel :: Traversable f => BindingLevel -> f MetaPtr -> Expand ()
+pruneLevel l = traverse_ reduce
+  where
+    reduce ptr =
+      modifyState $
+      over (expanderTypeStore . at ptr) $
+      fmap (over varLevel (min l))
+
+linkToType :: MetaPtr -> Ty -> Expand ()
+linkToType var ty = do
+  lvl <- view varLevel <$> derefType var
+  occursCheck var ty
+  pruneLevel lvl =<< metas ty
+  setTVKind var (Link (unTy ty))
+
+freshMeta :: Expand MetaPtr
+freshMeta = do
+  lvl <- currentBindingLevel
+  ptr <- liftIO $ newMetaPtr
+  modifyState (set (expanderTypeStore . at ptr) (Just (TVar NoLink lvl)))
+  return ptr

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -14,7 +14,9 @@ import Scope
 import ShortShow
 import Signals
 import SplitCore
+import SplitType
 import Syntax
+import Type
 import Value
 
 data MacroDest
@@ -22,8 +24,14 @@ data MacroDest
   | DeclDest DeclPtr Scope DeclValidityPtr
   deriving Show
 
+data TypeSpec
+  = CompleteType Ty
+  | IncompleteType SplitTypePtr
+  deriving Show
+
 data ExpanderTask
   = ExpandSyntax MacroDest Syntax
+  | ExpandType SplitTypePtr Syntax
   | AwaitingSignal MacroDest Signal [Closure]
   | AwaitingMacro MacroDest TaskAwaitMacro
   | AwaitingDefn Var Ident Binding SplitCorePtr SplitCorePtr Syntax
@@ -35,6 +43,7 @@ data ExpanderTask
   | InterpretMacroAction MacroDest MacroAction [Closure]
   | ContinueMacroAction MacroDest Value [Closure]
   | EvalDefnAction Var Ident Phase SplitCorePtr
+  | TypeCheck SplitCorePtr TypeSpec
   deriving (Show)
 
 data TaskAwaitMacro = TaskAwaitMacro
@@ -53,6 +62,7 @@ instance ShortShow TaskAwaitMacro where
 
 instance ShortShow ExpanderTask where
   shortShow (ExpandSyntax _dest stx) = "(ExpandSyntax " ++ T.unpack (pretty stx) ++ ")"
+  shortShow (ExpandType _dest stx) = "(ExpandType " ++ T.unpack (pretty stx) ++ ")"
   shortShow (AwaitingSignal _dest on _k) = "(AwaitingSignal " ++ show on ++ ")"
   shortShow (AwaitingDefn _x n _b _defn _dest stx) =
     "(AwaitingDefn " ++ shortShow n ++ " " ++ shortShow stx ++ ")"
@@ -62,6 +72,7 @@ instance ShortShow ExpanderTask where
   shortShow (InterpretMacroAction _dest act kont) = "(InterpretMacroAction " ++ show act ++ " " ++ show kont ++ ")"
   shortShow (ContinueMacroAction _dest value kont) = "(ContinueMacroAction " ++ show value ++ " " ++ show kont ++ ")"
   shortShow (EvalDefnAction var name phase _expr) = "(EvalDefnAction " ++ show var ++ " " ++ shortShow name ++ " " ++ show phase ++ ")"
+  shortShow (TypeCheck _ _) = "(TypeCheck _ _)"
 
 instance Pretty VarInfo ExpanderTask where
   pp _ task = string (shortShow task)

--- a/src/PartialType.hs
+++ b/src/PartialType.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TemplateHaskell #-}
+module PartialType where
+
+import Control.Lens
+
+import Type
+
+newtype PartialType = PartialType
+  { unPartialType :: Maybe (TyF PartialType) }
+  deriving (Eq, Show)
+makePrisms ''PartialType
+
+nonPartialType :: Ty -> PartialType
+nonPartialType = PartialType . Just . fmap nonPartialType . unTy
+
+runPartialType :: PartialType -> Maybe Ty
+runPartialType (PartialType Nothing) = Nothing
+runPartialType (PartialType (Just t)) =
+  traverse runPartialType t >>= pure . Ty

--- a/src/SplitType.hs
+++ b/src/SplitType.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+module SplitType where
+
+import Control.Lens hiding (children)
+import Control.Monad.Writer
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Unique
+
+import PartialType
+import Type
+
+newtype SplitTypePtr = SplitTypePtr Unique
+  deriving (Eq, Ord)
+
+instance Show SplitTypePtr where
+  show (SplitTypePtr i) = "(SplitTypePtr " ++ show (hashUnique i) ++ ")"
+
+newSplitTypePtr :: IO SplitTypePtr
+newSplitTypePtr = SplitTypePtr <$> newUnique
+
+data SplitType = SplitType
+  { _splitTypeRoot :: SplitTypePtr
+  , _splitTypeDescendants :: Map SplitTypePtr (TyF SplitTypePtr)
+  }
+makeLenses ''SplitType
+
+unsplitType :: SplitType -> PartialType
+unsplitType t = PartialType $ go (view splitTypeRoot t)
+  where
+    go :: SplitTypePtr -> Maybe (TyF PartialType)
+    go ptr = do
+      this <- view (splitTypeDescendants . at ptr) t
+      return (fmap (PartialType . go) this)
+
+splitType :: PartialType -> IO SplitType
+splitType partialType = do
+  root <- newSplitTypePtr
+  ((), childMap) <- runWriterT $ go root (unPartialType partialType)
+  return $ SplitType root childMap
+  where
+    go ::
+      SplitTypePtr -> Maybe (TyF PartialType) ->
+      WriterT (Map SplitTypePtr (TyF SplitTypePtr)) IO ()
+    go _ Nothing = pure ()
+    go place (Just t) = do
+      children <- flip traverse t $ \p -> do
+        here <- liftIO newSplitTypePtr
+        go here (unPartialType p)
+        pure here
+      tell $ Map.singleton place children

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+module Type where
+
+import Control.Lens
+import Data.Map (Map)
+import Data.Unique
+import Numeric.Natural
+
+newtype MetaPtr = MetaPtr Unique deriving (Eq, Ord)
+
+newMetaPtr :: IO MetaPtr
+newMetaPtr = MetaPtr <$> newUnique
+
+instance Show MetaPtr where
+  show (MetaPtr i) = "(MetaPtr " ++ show (hashUnique i) ++ ")"
+
+data TyF t
+  = TUnit
+  | TBool
+  | TSyntax
+  | TIdent
+  | TSignal
+  | TFun t t
+  | TMacro t
+  | TList t
+  | TSchemaVar Natural
+  | TMetaVar MetaPtr
+  deriving (Eq, Foldable, Functor, Show, Traversable)
+makePrisms ''TyF
+
+data VarKind t = NoLink | Link (TyF t)
+  deriving (Functor, Show)
+makePrisms ''VarKind
+
+newtype BindingLevel = BindingLevel Natural
+  deriving (Eq, Ord, Show)
+makePrisms ''BindingLevel
+
+data TVar t = TVar
+  { _varKind :: !(VarKind t)
+  , _varLevel :: !BindingLevel
+  }
+  deriving (Functor, Show)
+makeLenses ''TVar
+
+newtype TypeStore t = TypeStore (Map MetaPtr (TVar t))
+  deriving (Functor, Monoid, Semigroup, Show)
+
+type instance Index (TypeStore t) = MetaPtr
+type instance IxValue (TypeStore t) = TVar t
+
+instance Ixed (TypeStore t) where
+  ix var f (TypeStore env) = TypeStore <$> ix var f env
+
+instance At (TypeStore t) where
+  at x f (TypeStore env) = TypeStore <$> at x f env
+
+data Scheme t = Scheme Natural t deriving Show
+makeLenses ''Scheme
+
+newtype Ty = Ty
+  { unTy :: TyF Ty }
+  deriving (Eq, Show)
+makePrisms ''Ty


### PR DESCRIPTION
This is still in an early state.

To do before merging:
 * [ ] Finish type checker infrastructure (add `let`, generalization, etc)
 * [ ] Add typing rules for all `CoreF` constructors
 * [ ] Track source locations on `Core` terms to report type error locations
 * [ ] Tests, tests, more tests
 * [ ] Invoke type checker where needed, not just on annotations