### PR TITLE
adding some comments

### DIFF
--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -32,7 +32,8 @@
     [[cons a d]
      (syntax-case d
        [() a]
-       [_ (last-stx d)])]
+       [_ (last-stx d)])]  -- note that this is a recursive call to last-stx, whereas earlier (e.g. in n-ary-app.kl)
+                           -- we'd have to return the syntax of a macro call to last-stx.
     [_ stx])]
 
 [example (last-stx '(a b c d e f g))]

--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -26,7 +26,6 @@
 
 [example (const 'a 'b)]
 
--- (last-stx foo bar baz) => baz
 [defun last-stx (stx)
   (syntax-case stx
     [[cons a d]

--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -8,6 +8,13 @@
      [lambda (rec) (fun [lambda (x) (rec rec x)])])]]
 
 [define-macros
+  -- (defun f (x y z)
+  --   (... (f foo bar baz) ...))
+  -- =>
+  -- (define f
+  --   (fix (lambda (f)
+  --          (lambda (x y z)
+  --            ... (f foo bar baz) ...))))
   ([defun
     [lambda (stx)
       (syntax-case stx
@@ -19,6 +26,7 @@
 
 [example (const 'a 'b)]
 
+-- (last-stx foo bar baz) => baz
 [defun last-stx (stx)
   (syntax-case stx
     [[cons a d]

--- a/examples/let1.kl
+++ b/examples/let1.kl
@@ -1,6 +1,6 @@
 #lang kernel
 
-[import [shift (only kernel lambda syntax-case cons-list-syntax vec-syntax pure) 1]]
+[import [shift (only kernel lambda syntax-case cons-list-syntax list-syntax pure) 1]]
 [import [shift (only "quasiquote.kl" quasiquote unquote) 1]]
 
 -- Let for a single variable
@@ -10,9 +10,9 @@
      [lambda
        [stx]
        (syntax-case stx
-         [[vec [_ pair body]]
+         [[list [_ pair body]]
           (syntax-case pair
-            [[vec [idt expr]]
+            [[list [idt expr]]
              [pure `[[lambda [,idt] ,body] ,expr]]])])]])]
 
 [define id [lambda [x] x]]

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -5,6 +5,7 @@
 
 
 [define-macros
+  -- (my-app f foo bar baz) => (((f foo) bar) baz)
   ([my-app
     [lambda [stx]
       (syntax-case stx
@@ -22,6 +23,12 @@
                     more-args
                     stx]
                   stx]]])])])]]
+   -- (my-lam (x y z) ...)
+   -- =>
+   -- (lambda (x)
+   --   (lambda (y)
+   --     (lambda (z)
+   --       ...)))
    [my-lam
     [lambda [stx]
      (syntax-case stx
@@ -37,6 +44,7 @@
            [pure [list-syntax [[quote lambda] args body] stx]]])])]])]
 
 [define-macros
+  -- (f foo bar baz) => (my-app foo bar baz)
   ([#%app
     [lambda [stx]
      (syntax-case stx
@@ -44,6 +52,7 @@
        [pure [cons-list-syntax [quote my-app] args stx]]])]])]
 
 [define-macros
+  -- (lambda (x y z) ...) => (my-lam (x y z) ...)
   ([lambda
     [lambda [stx]
      (syntax-case stx

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -23,12 +23,12 @@
                     more-args
                     stx]
                   stx]]])])])]]
-   -- (my-lam (x y z) ...)
+   -- (my-lam (x y z) body
    -- =>
    -- (lambda (x)
    --   (lambda (y)
    --     (lambda (z)
-   --       ...)))
+   --       body)))
    [my-lam
     [lambda [stx]
      (syntax-case stx

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -17,9 +17,9 @@
               [[cons arg0 more-args]
                [pure
                 [cons-list-syntax
-                  [quote my-app]
+                  'my-app
                   [cons-list-syntax
-                    [list-syntax [[quote #%app] fun arg0] stx]
+                    [list-syntax ['#%app fun arg0] stx]
                     more-args
                     stx]
                   stx]]])])])]]
@@ -36,12 +36,12 @@
         (syntax-case args
           [() [pure body]]
           [[cons arg0 more-args]
-           [pure [list-syntax [[quote lambda]
+           [pure [list-syntax ['lambda
                                [list-syntax [arg0] arg0]
-                               [list-syntax [[quote my-lam] more-args body] stx]]
+                               [list-syntax ['my-lam more-args body] stx]]
                            stx]]]
           [[list [arg]]
-           [pure [list-syntax [[quote lambda] args body] stx]]])])]])]
+           [pure [list-syntax ['lambda args body] stx]]])])]])]
 
 [define-macros
   -- (f foo bar baz) => (my-app foo bar baz)
@@ -49,7 +49,7 @@
     [lambda [stx]
      (syntax-case stx
       [[cons _ args]
-       [pure [cons-list-syntax [quote my-app] args stx]]])]])]
+       [pure [cons-list-syntax 'my-app args stx]]])]])]
 
 [define-macros
   -- (lambda (x y z) ...) => (my-lam (x y z) ...)
@@ -57,13 +57,13 @@
     [lambda [stx]
      (syntax-case stx
       [[list [_ args body]]
-       [pure [list-syntax [[quote my-lam] args body] stx]]])]])]
+       [pure [list-syntax ['my-lam args body] stx]]])]])]
 
 [define id [lambda (x) x]]
 
 [define const [lambda (x y) x]]
 
-[example (const [quote a] [quote b])]
+[example (const 'a 'b)]
 
 [define compose [lambda (f g x) (f (g x))]]
 

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -84,7 +84,7 @@ data CoreF core
   | CoreSyntaxError (SyntaxError core)  -- :: Macro a
   | CoreSendSignal core                 -- :: Signal -> Macro ()
   | CoreWaitSignal core                 -- :: Signal -> Macro ()
-  | CoreIdentEq HowEq core core
+  | CoreIdentEq HowEq core core         -- :: HowEq -> Syntax -> Syntax -> Macro Bool
   | CoreLog core
   | CoreSyntax Syntax
   | CoreCase core [(Pattern, core)]

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -84,7 +84,8 @@ data CoreF core
   | CoreSyntaxError (SyntaxError core)  -- :: Macro a
   | CoreSendSignal core                 -- :: Signal -> Macro ()
   | CoreWaitSignal core                 -- :: Signal -> Macro ()
-  | CoreIdentEq HowEq core core         -- :: HowEq -> Syntax -> Syntax -> Macro Bool
+  | CoreIdentEq HowEq core core         -- bound-identifier=? :: Syntax -> Syntax -> Macro Bool
+                                        -- free-identifier=?  :: Syntax -> Syntax -> Macro Bool
   | CoreLog core
   | CoreSyntax Syntax
   | CoreCase core [(Pattern, core)]


### PR DESCRIPTION
I was reading the examples which use `{bound,free}-identifier=?` and I took the opportunity to add a few comments here and there. And to simplify some occurrences of `[quote a]` with `'a`. Probably more to come as I continue to read the examples.