### PR TITLE
make bound-identifier=? pure

### DIFF
--- a/commentary.md
+++ b/commentary.md
@@ -124,9 +124,9 @@ The macro monad includes operations to compare the binding information of identi
 
 #### Macro monad effects
 
- * `bound-identifier=? : Syntax -> Syntax -> Macro Bool` determines whether its arguments are identifiers such that each would bind the other at the current phase. In practice, this means that their scope sets are identical. If either argument is not an identifier, fails.
- 
  * `free-identifier=? : Syntax -> Syntax -> Macro Bool` determines whether its arguments are identifiers that refer to the same binding in the current context. If either argument is not an identifier, fails.
+ 
+ * `bound-identifier=? : Syntax -> Syntax -> Bool` is not a monadic effect, but is documented here because it is so similar to `free-identifier=?`. It determines whether its arguments are identifiers such that each would bind the other at the current phase. In practice, this means that their scope sets are identical. If either argument is not an identifier, fails.
  
  * `syntax-error : ∀α. Syntax -> Syntax * -> Macro α` fails, using its first argument as the reason for failure and the remaining arguments as source locations involved in the failure. This should probably be rewritten to take a list instead of being variable arity, once we have lists in the language.
  

--- a/examples/bound-identifier.kl
+++ b/examples/bound-identifier.kl
@@ -10,5 +10,7 @@
                      ''t
                      ''f))))))))
 
+(example (bound-identifier=? 'x 'x))
+(example (bound-identifier=? 'x 'y))
 (example (m x x))
 (example (m x y))

--- a/examples/bound-identifier.kl
+++ b/examples/bound-identifier.kl
@@ -6,9 +6,9 @@
   ((m (lambda (stx)
         (syntax-case stx
           ((list (_ x y))
-           (>>= (bound-identifier=? x y)
-                (lambda (bool)
-                  (pure (if bool ''t ''f))))))))))
+           (pure (if (bound-identifier=? x y)
+                     ''t
+                     ''f))))))))
 
 (example (m x x))
 (example (m x y))

--- a/examples/let1.kl
+++ b/examples/let1.kl
@@ -1,6 +1,6 @@
 #lang kernel
 
-[import [shift (only kernel lambda syntax-case cons-list-syntax vec-syntax pure) 1]]
+[import [shift (only kernel lambda syntax-case cons-list-syntax list-syntax pure) 1]]
 [import [shift (only "quasiquote.kl" quasiquote unquote) 1]]
 
 -- Let for a single variable
@@ -10,9 +10,9 @@
      [lambda
        [stx]
        (syntax-case stx
-         [[vec [_ pair body]]
+         [[list [_ pair body]]
           (syntax-case pair
-            [[vec [idt expr]]
+            [[list [idt expr]]
              [pure `[[lambda [,idt] ,body] ,expr]]])])]])]
 
 [define id [lambda [x] x]]

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -97,13 +97,10 @@ instance Pretty VarInfo core => Pretty VarInfo (CoreF core) where
     group $ text "send-signal" <+> pp env arg
   pp env (CoreWaitSignal arg) =
     group $ text "wait-signal" <+> pp env arg
-  pp env (CoreIdentEq how e1 e2) =
-    group $ text opName <+> pp env e1 <+> pp env e2
-    where
-      opName =
-        case how of
-          Free -> "free-identifier=?"
-          Bound -> "bound-identifier=?"
+  pp env (CoreFreeIdentEq e1 e2) =
+    group $ text "free-identifier=?" <+> pp env e1 <+> pp env e2
+  pp env (CoreBoundIdentEq e1 e2) =
+    group $ text "bound-identifier=?" <+> pp env e1 <+> pp env e2
   pp env (CoreLog msg) =
     group (hang 2 (vsep ["log", pp env msg]))
   pp env (CoreSyntax stx) =
@@ -313,13 +310,8 @@ instance Pretty VarInfo MacroAction where
     text "send-signal" <+> viaShow s
   pp _env (MacroActionWaitSignal s) =
     text "wait-signal" <+> viaShow s
-  pp env (MacroActionIdentEq how v1 v2) =
-    group $ parens $ vsep [text opName, pp env v1, pp env v2]
-    where
-      opName =
-        case how of
-          Free  -> "free-identifier=?"
-          Bound -> "bound-identifier=?"
+  pp env (MacroActionFreeIdentEq v1 v2) =
+    group $ parens $ vsep [text "free-identifier=?", pp env v1, pp env v2]
   pp env (MacroActionLog stx) =
     hang 2 $ group $ vsep [text "log", pp env stx]
 

--- a/src/Value.hs
+++ b/src/Value.hs
@@ -20,7 +20,7 @@ data MacroAction
   | MacroActionSyntaxError (SyntaxError Syntax)
   | MacroActionSendSignal Signal
   | MacroActionWaitSignal Signal
-  | MacroActionIdentEq HowEq Value Value
+  | MacroActionFreeIdentEq Value Value
   | MacroActionLog Syntax
   deriving (Eq, Show)
 

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -409,11 +409,10 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
         , ( "examples/bound-identifier.kl"
           , \_m exampleVals ->
               case exampleVals of
-                [ValueSyntax (Syntax (Stx _ _ (Id a))), ValueSyntax (Syntax (Stx _ _ (Id b)))] -> do
-                  assertAlphaEq "First example is true" a "t"
-                  assertAlphaEq "Second example is false" b "f"
-                _ ->
-                  assertFailure "Expected two symbols in example"
+                [ValueBool True, ValueBool False, ValueSyntax (Syntax (Stx _ _ (Id "t"))), ValueSyntax (Syntax (Stx _ _ (Id "f")))] -> do
+                  pure ()
+                [_,_,_,_] -> assertFailure $ "Wrong example values: " ++ show exampleVals
+                _ -> assertFailure "Wrong number of examples in file"
           )
         ]
       ]


### PR DESCRIPTION
`free-idenfitier=?` looks at the internal interpreter state (all the matching bindings in the current phase), and so it makes sense for it to be a side-effect in the `Macro` monad. However, `bound-identifier=?` only looks at the value of the identifiers being compared, so it doesn't need to be in the `Macro` monad.

Making it pure has two advantages. First, it is now possible to call `bound-identifier=?` outside of a macro. Second, it simplifies our paper, because we only need to worry about non-determinism coming from the `Macro` actions, so the fewer `Macro` actions the better.