### PR TITLE
declaration groups

### DIFF
--- a/examples/define-syntax-rule.kl
+++ b/examples/define-syntax-rule.kl
@@ -31,3 +31,5 @@
   (lambda (x y) body))
 
 (example ((lambda2 x y y) 'foo 'bar))  -- 'bar
+
+(export define-syntax-rule)

--- a/examples/double-define.golden
+++ b/examples/double-define.golden
@@ -1,0 +1,2 @@
+Signal 1 : Signal
+Signal 1 : Signal

--- a/examples/double-define.kl
+++ b/examples/double-define.kl
@@ -1,0 +1,12 @@
+#lang kernel
+
+(import "define-syntax-rule.kl")
+
+(define-syntax-rule (double-define x y value)
+  (group
+    (define x value)
+    (define y value)))
+
+(double-define a b 1)
+(example a)
+(example b)

--- a/examples/group.golden
+++ b/examples/group.golden
@@ -1,0 +1,6 @@
+Signal 1 : Signal
+Signal 1 : Signal
+Signal 1 : Signal
+Signal 10 : Signal
+Signal 10 : Signal
+Signal 10 : Signal

--- a/examples/group.kl
+++ b/examples/group.kl
@@ -1,0 +1,20 @@
+#lang kernel
+(import (shift kernel 1))
+
+(define a 1)
+(meta
+  (define a 10))
+(group
+  (define b a)
+  (define c b)
+  (meta
+    (define b a)
+    (define c b)))
+
+(example a)
+(example b)
+(example c)
+(meta
+  (example a)
+  (example b)
+  (example c))

--- a/examples/phase1.kl
+++ b/examples/phase1.kl
@@ -4,10 +4,13 @@
 
 
 [meta
+  [define return
+    [lambda [e]
+      [pure e]]]
   [define m-impl
     [lambda [s]
       (syntax-case s
-        [[list [_ e]] [pure e]])]]]
+        [[list [_ e]] [return e]])]]]
 
 [define-macros ([m m-impl])]
 

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -95,7 +95,7 @@ mainWithOptions opts =
           mn <- moduleNameFromPath file
           ctx <- mkInitContext mn
           void $ execExpand initializeKernel ctx
-          st <- flip execExpand ctx $ completely $ do
+          st <- flip execExpand ctx $ do
             visit mn >> getState
           case st of
             Left err -> prettyPrintLn err *> fail ""

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -95,7 +95,7 @@ mainWithOptions opts =
           mn <- moduleNameFromPath file
           ctx <- mkInitContext mn
           void $ execExpand initializeKernel ctx
-          st <- execExpand (visit mn >> getState) ctx
+          st <- execExpand (fullyVisit mn >> getState) ctx
           case st of
             Left err -> prettyPrintLn err *> fail ""
             Right result ->
@@ -127,7 +127,7 @@ repl ctx startWorld = do
            Right ok ->
              do putStrLn "Parser output:"
                 T.putStrLn (syntaxText ok)
-                c <- execExpand (expandExpr ok) ctx
+                c <- execExpand (fullyExpandExpr ok) ctx
                 case c of
                   Left err -> putStr "Expander error: " *>
                               prettyPrintLn err

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -95,7 +95,8 @@ mainWithOptions opts =
           mn <- moduleNameFromPath file
           ctx <- mkInitContext mn
           void $ execExpand initializeKernel ctx
-          st <- execExpand (fullyVisit mn >> getState) ctx
+          st <- flip execExpand ctx $ completely $ do
+            visit mn >> getState
           case st of
             Left err -> prettyPrintLn err *> fail ""
             Right result ->
@@ -127,7 +128,7 @@ repl ctx startWorld = do
            Right ok ->
              do putStrLn "Parser output:"
                 T.putStrLn (syntaxText ok)
-                c <- execExpand (fullyExpandExpr ok) ctx
+                c <- flip execExpand ctx $ completely $ expandExpr ok
                 case c of
                   Left err -> putStr "Expander error: " *>
                               prettyPrintLn err

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -609,6 +609,11 @@ initializeKernel = do
             inEarlierPhase $
               expandDeclForms subDest mempty vp =<< addRootScope subDecls
         )
+      , ( "group"
+        , \dest vp stx -> do
+            (_ :: Syntax, decls) <- mustHaveShape stx
+            expandDeclForms dest mempty vp decls
+        )
       ]
       where
         importSpec :: Syntax -> Expand ImportSpec

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -1478,6 +1478,11 @@ expandDeclForms dest scs vp (Syntax (Stx stxScs loc (List (d:ds)))) = do
   cdrDest <- liftIO $ newDeclTreePtr
   carValidityPtr <- newDeclValidityPtr
   linkDeclTree dest (DeclTreeBranch carDest cdrDest)
+
+  -- This is where the ScopeSet is threaded through: from the input scs, to the
+  -- car's expandDeclForm task, who adds some Scopes to it and writes the result
+  -- to carValidityPtr, which is read (and blocked on) by the forkExpandDeclForms
+  -- task, who adds even more Scopes and writes the result to vp.
   forkExpandDeclForms cdrDest carValidityPtr vp
     (Syntax (Stx stxScs loc (List ds)))
   expandDeclForm carDest scs carValidityPtr =<< addRootScope d

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -563,18 +563,16 @@ initializeKernel = do
         )
       , ( "example"
         , \ dest scs vp stx -> do
-            p <- currentPhase
             Stx _ _ (_ :: Syntax, expr) <- mustHaveEntries stx
             exprDest <- liftIO $ newSplitCorePtr
             sch <- liftIO newSchemePtr
             linkOneDecl dest (Example (view (unSyntax . stxSrcLoc) stx) sch exprDest)
-            sc <- freshScope $ T.pack $ "For example at " ++ shortShow (stxLoc stx)
             t <- inTypeBinder do
               t <- Ty . TMetaVar <$> freshMeta
-              forkExpandSyntax (ExprDest t exprDest) (addScope p expr sc)
+              forkExpandSyntax (ExprDest t exprDest) expr
               return t
             forkGeneralizeType exprDest t sch
-            linkDeclValidity vp (ScopeSet.insertAtPhase p sc scs)
+            linkDeclValidity vp scs
         )
       , ( "import"
          -- TODO Make import spec language extensible and use bindings rather than literals

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -603,11 +603,11 @@ initializeKernel = do
         )
       , ( "meta"
         , \dest vp stx -> do
-            Stx _ _ (_ :: Syntax, subDecl) <- mustHaveEntries stx
+            (_ :: Syntax, subDecls) <- mustHaveShape stx
             subDest <- newDeclTreePtr
             linkOneDecl dest (Meta subDest)
             inEarlierPhase $
-              expandDeclForm subDest vp =<< addRootScope subDecl
+              expandDeclForms subDest mempty vp =<< addRootScope subDecls
         )
       ]
       where

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -1496,9 +1496,9 @@ expandDeclForms dest scs vp (Syntax (Stx stxScs loc (List (d:ds)))) = do
   -- car's expandDeclForm task, who adds some Scopes to it and writes the result
   -- to carValidityPtr, which is read (and blocked on) by the forkExpandDeclForms
   -- task, who adds even more Scopes and writes the result to vp.
+  expandDeclForm carDest scs carValidityPtr =<< addRootScope d
   forkExpandDeclForms cdrDest carValidityPtr vp
     (Syntax (Stx stxScs loc (List ds)))
-  expandDeclForm carDest scs carValidityPtr =<< addRootScope d
 expandDeclForms _dest _scs _vp _stx =
   error "TODO real error message - malformed module body"
 

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -1103,7 +1103,7 @@ expandTasks = do
       forM_ more runTask
       newTasks <- getTasks
       if taskIDs tasks  == taskIDs newTasks
-        then throwError (NoProgress (map (view _3) newTasks))
+        then return ()
         else expandTasks
   where
     taskIDs = Set.fromList . map (view _1)

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -116,7 +116,7 @@ expandModule thisMod src = do
   local (set (expanderLocal . expanderModuleName) thisMod) do
     lang <- mustBeModName (view moduleLanguage src)
     initializeLanguage lang
-    declTreeDest <- liftIO $ newDeclTreePtr
+    declTreeDest <- newDeclTreePtr
     vp <- newDeclValidityPtr
     modifyState $ set expanderModuleTop $ Just declTreeDest
     decls <- addModuleScope (view moduleContents src)
@@ -464,7 +464,7 @@ initializeKernel = do
               Just _ ->
                 error "TODO throw real error - already expanding a module"
               Nothing -> do
-                bodyPtr <- liftIO newDeclTreePtr
+                bodyPtr <- newDeclTreePtr
                 modifyState $ set expanderModuleTop (Just bodyPtr)
                 Stx _ _ (_ :: Syntax, name, imports, body, exports) <- mustHaveEntries stx
                 _actualName <- mustBeIdent name
@@ -604,7 +604,7 @@ initializeKernel = do
       , ( "meta"
         , \dest vp stx -> do
             Stx _ _ (_ :: Syntax, subDecl) <- mustHaveEntries stx
-            subDest <- liftIO newDeclTreePtr
+            subDest <- newDeclTreePtr
             linkOneDecl dest (Meta subDest)
             inEarlierPhase $
               expandDeclForm subDest vp =<< addRootScope subDecl
@@ -1491,8 +1491,8 @@ expandDeclForms dest scs vp (Syntax (Stx _ _ (List []))) = do
   linkDeclTree dest DeclTreeLeaf
   linkDeclValidity vp scs
 expandDeclForms dest scs vp (Syntax (Stx stxScs loc (List (d:ds)))) = do
-  headDest <- liftIO $ newDeclTreePtr
-  tailDest <- liftIO $ newDeclTreePtr
+  headDest <- newDeclTreePtr
+  tailDest <- newDeclTreePtr
   headValidityPtr <- newDeclValidityPtr
   linkDeclTree dest (DeclTreeBranch headDest tailDest)
 

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -590,13 +590,13 @@ initializeKernel = do
             linkDeclValidity vp (ScopeSet.insertUniversally sc scs)
         )
       , ( "export"
-        , \dest _scs vp stx -> do
+        , \dest scs vp stx -> do
             Stx _ _ (_, protoSpec) <- mustBeCons stx
             exported <- exportSpec stx protoSpec
             es <- getExports exported
             modifyState $ over expanderModuleExports $ (<> es)
             linkOneDecl dest (Export exported)
-            linkDeclValidity vp mempty
+            linkDeclValidity vp scs
         )
       , ( "meta"
         , \dest scs vp stx -> do

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -120,8 +120,9 @@ expandModule thisMod src = do
     vp <- newDeclValidityPtr
     modifyState $ set expanderModuleTop $ Just declTreeDest
     decls <- addModuleScope (view moduleContents src)
-    expandDeclForms declTreeDest mempty vp decls
-    expandTasks
+    completely do
+      expandDeclForms declTreeDest mempty vp decls
+      expandTasks
     body <- getDeclGroup declTreeDest
     let modName = view moduleSource src
     let theModule = Module { _moduleName = modName

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -583,14 +583,13 @@ initializeKernel = do
             linkDeclValidity vp (ScopeSet.singleUniversalScope sc)
         )
       , ( "export"
-        , \sc dest vp stx -> do
+        , \_sc dest vp stx -> do
             Stx _ _ (_, protoSpec) <- mustBeCons stx
             exported <- exportSpec stx protoSpec
-            p <- currentPhase
             es <- getExports exported
             modifyState $ over expanderModuleExports $ (<> es)
             linkOneDecl dest (Export exported)
-            linkDeclValidity vp (ScopeSet.singleScopeAtPhase sc p)
+            linkDeclValidity vp mempty
         )
       , ( "meta"
         , \sc dest vp stx -> do

--- a/src/Expander/DeclScope.hs
+++ b/src/Expander/DeclScope.hs
@@ -2,6 +2,11 @@ module Expander.DeclScope where
 
 import Data.Unique
 
+-- | A 'DeclValidityPtr' gets filled once we know at which phases an identifier
+-- is bound (but before we know exactly what it is that this identifier is
+-- bound to). In order to determine what a given identifier means, we must wait
+-- until all the declarations listed earlier in the file have had their
+-- 'DeclValidityPtr's filled.
 newtype DeclValidityPtr = DeclValidityPtr Unique
   deriving (Eq, Ord)
 

--- a/src/Expander/DeclScope.hs
+++ b/src/Expander/DeclScope.hs
@@ -2,15 +2,15 @@ module Expander.DeclScope where
 
 import Data.Unique
 
--- | A 'DeclValidityPtr' gets filled with a 'ScopeSet' consisting of all the
--- scopes introduced by a declaration or a declaration group, so that later
--- code can see the identifiers they bind.
+-- | A 'DeclOutputScopesPtr' gets filled with a 'ScopeSet' consisting of all the
+-- scopes introduced by a declaration or a declaration group, so that later code
+-- can see the identifiers they bind.
 --
--- Note that 'DeclValidityPtr' gets filled once we know which _names_ get
+-- Note that 'DeclOutputScopesPtr' gets filled once we know which _names_ get
 -- bound, the values to which they are bound may not be fully-expanded yet.
-newtype DeclValidityPtr = DeclValidityPtr Unique
+newtype DeclOutputScopesPtr = DeclOutputScopesPtr Unique
   deriving (Eq, Ord)
 
-instance Show DeclValidityPtr where
-  show (DeclValidityPtr u) = "(DeclValidityPtr " ++ show (hashUnique u) ++ ")"
+instance Show DeclOutputScopesPtr where
+  show (DeclOutputScopesPtr u) = "(DeclOutputScopesPtr " ++ show (hashUnique u) ++ ")"
 

--- a/src/Expander/DeclScope.hs
+++ b/src/Expander/DeclScope.hs
@@ -2,10 +2,9 @@ module Expander.DeclScope where
 
 import Data.Unique
 
--- | A 'DeclValidityPtr' gets filled with a 'ScopeSet' representing an
--- environment. Each 'Scope' in this 'ScopeSet' corresponds to an identifier
--- which is bound in that environment, and the 'ScopeSet' indicates the phase
--- or phases in which each 'Scope' is valid.
+-- | A 'DeclValidityPtr' gets filled with a 'ScopeSet' consisting of all the
+-- scopes introduced by a declaration or a declaration group, so that later
+-- code can see the identifiers they bind.
 --
 -- Note that 'DeclValidityPtr' gets filled once we know which _names_ get
 -- bound, the values to which they are bound may not be fully-expanded yet.

--- a/src/Expander/DeclScope.hs
+++ b/src/Expander/DeclScope.hs
@@ -2,11 +2,13 @@ module Expander.DeclScope where
 
 import Data.Unique
 
--- | A 'DeclValidityPtr' gets filled once we know at which phases an identifier
--- is bound (but before we know exactly what it is that this identifier is
--- bound to). In order to determine what a given identifier means, we must wait
--- until all the declarations listed earlier in the file have had their
--- 'DeclValidityPtr's filled.
+-- | A 'DeclValidityPtr' gets filled with a 'ScopeSet' representing an
+-- environment. Each 'Scope' in this 'ScopeSet' corresponds to an identifier
+-- which is bound in that environment, and the 'ScopeSet' indicates the phase
+-- or phases in which each 'Scope' is valid.
+--
+-- Note that 'DeclValidityPtr' gets filled once we know which _names_ get
+-- bound, the values to which they are bound may not be fully-expanded yet.
 newtype DeclValidityPtr = DeclValidityPtr Unique
   deriving (Eq, Ord)
 

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -187,7 +187,7 @@ data EValue
   = EPrimMacro (Ty -> SplitCorePtr -> Syntax -> Expand ()) -- ^ For special forms
   | EPrimTypeMacro (SplitTypePtr -> Syntax -> Expand ()) -- ^ For type-level special forms
   | EPrimModuleMacro (Syntax -> Expand ())
-  | EPrimDeclMacro (DeclTreePtr -> ScopeSet -> DeclValidityPtr -> Syntax -> Expand ())
+  | EPrimDeclMacro (DeclTreePtr -> DeclValidityPtr -> Syntax -> Expand ())
   | EVarMacro !Var -- ^ For bound variables (the Unique is the binding site of the var)
   | ETypeVar !Natural -- ^ For bound type variables (user-written Skolem variables or in datatype definitions)
   | EUserMacro !MacroVar -- ^ For user-written macros
@@ -463,9 +463,9 @@ forkAwaitingMacro b v x mdest dest stx =
   forkExpanderTask $ AwaitingMacro dest (TaskAwaitMacro b v x [mdest] mdest stx)
 
 forkAwaitingDeclMacro ::
-  Binding -> MacroVar -> Ident -> SplitCorePtr -> DeclTreePtr -> ScopeSet -> DeclValidityPtr -> Syntax -> Expand ()
-forkAwaitingDeclMacro b v x mdest dest scs vp stx = do
-  forkExpanderTask $ AwaitingMacro (DeclTreeDest dest scs vp) (TaskAwaitMacro b v x [mdest] mdest stx)
+  Binding -> MacroVar -> Ident -> SplitCorePtr -> DeclTreePtr -> DeclValidityPtr -> Syntax -> Expand ()
+forkAwaitingDeclMacro b v x mdest dest vp stx = do
+  forkExpanderTask $ AwaitingMacro (DeclTreeDest dest vp) (TaskAwaitMacro b v x [mdest] mdest stx)
 
 forkAwaitingDefn ::
   Var -> Ident -> Binding -> SplitCorePtr ->

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -94,7 +94,7 @@ module Expander.Monad
   , expanderCurrentTransformerEnvs
   , expanderDefTypes
   , expanderTypeStore
-  , expanderDeclPhases
+  , expanderDeclValidities
   , expanderExpansionEnv
   , expanderExpressionTypes
   , expanderKernelBindings
@@ -243,7 +243,7 @@ data ExpanderState = ExpanderState
   , _expanderModuleRoots :: !(Map ModuleName Scope)
   , _expanderKernelBindings :: !BindingTable
   , _expanderKernelExports :: !Exports
-  , _expanderDeclPhases :: !(Map DeclValidityPtr PhaseSpec)
+  , _expanderDeclValidities :: !(Map DeclValidityPtr PhaseSpec)
   , _expanderCurrentEnvs :: !(Map Phase (Env Var Value))
   , _expanderCurrentTransformerEnvs :: !(Map Phase (Env MacroVar Value))
   , _expanderCurrentDatatypes :: !(Map Phase (Map Datatype DatatypeInfo))
@@ -277,7 +277,7 @@ initExpanderState = ExpanderState
   , _expanderModuleRoots = Map.empty
   , _expanderKernelBindings = mempty
   , _expanderKernelExports = noExports
-  , _expanderDeclPhases = Map.empty
+  , _expanderDeclValidities = Map.empty
   , _expanderCurrentEnvs = Map.empty
   , _expanderCurrentTransformerEnvs = Map.empty
   , _expanderCurrentDatatypes = Map.empty
@@ -473,8 +473,8 @@ forkEstablishConstructors ::
   DeclValidityPtr ->
   Datatype -> [(Ident, Constructor, [SplitTypePtr])] ->
   Expand ()
-forkEstablishConstructors pdest dt ctors =
-  forkExpanderTask $ EstablishConstructors pdest dt ctors
+forkEstablishConstructors vp dt ctors =
+  forkExpanderTask $ EstablishConstructors vp dt ctors
 
 forkInterpretMacroAction :: MacroDest -> MacroAction -> [Closure] -> Expand ()
 forkInterpretMacroAction dest act kont = do
@@ -686,4 +686,4 @@ datatypeInfo datatype = do
 
 nowValidAt :: DeclValidityPtr -> PhaseSpec -> Expand ()
 nowValidAt ptr p =
-  modifyState $ over expanderDeclPhases $ Map.insert ptr p
+  modifyState $ over expanderDeclValidities $ Map.insert ptr p

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -187,7 +187,7 @@ data EValue
   = EPrimMacro (Ty -> SplitCorePtr -> Syntax -> Expand ()) -- ^ For special forms
   | EPrimTypeMacro (SplitTypePtr -> Syntax -> Expand ()) -- ^ For type-level special forms
   | EPrimModuleMacro (Syntax -> Expand ())
-  | EPrimDeclMacro (Scope -> DeclTreePtr -> DeclValidityPtr -> Syntax -> Expand ())
+  | EPrimDeclMacro (DeclTreePtr -> ScopeSet -> DeclValidityPtr -> Syntax -> Expand ())
   | EVarMacro !Var -- ^ For bound variables (the Unique is the binding site of the var)
   | ETypeVar !Natural -- ^ For bound type variables (user-written Skolem variables or in datatype definitions)
   | EUserMacro !MacroVar -- ^ For user-written macros
@@ -463,9 +463,9 @@ forkAwaitingMacro b v x mdest dest stx =
   forkExpanderTask $ AwaitingMacro dest (TaskAwaitMacro b v x [mdest] mdest stx)
 
 forkAwaitingDeclMacro ::
-  Binding -> MacroVar -> Ident -> SplitCorePtr -> DeclTreePtr -> Scope -> DeclValidityPtr ->  Syntax -> Expand ()
-forkAwaitingDeclMacro b v x mdest dest sc ph stx = do
-  forkExpanderTask $ AwaitingMacro (DeclTreeDest dest sc ph) (TaskAwaitMacro b v x [mdest] mdest stx)
+  Binding -> MacroVar -> Ident -> SplitCorePtr -> DeclTreePtr -> ScopeSet -> DeclValidityPtr -> Syntax -> Expand ()
+forkAwaitingDeclMacro b v x mdest dest scs vp stx = do
+  forkExpanderTask $ AwaitingMacro (DeclTreeDest dest scs vp) (TaskAwaitMacro b v x [mdest] mdest stx)
 
 forkAwaitingDefn ::
   Var -> Ident -> Binding -> SplitCorePtr ->
@@ -475,12 +475,12 @@ forkAwaitingDefn x n b defn t dest stx =
   forkExpanderTask $ AwaitingDefn x n b defn t dest stx
 
 forkEstablishConstructors ::
-  Scope ->
+  ScopeSet ->
   DeclValidityPtr ->
   Datatype -> [(Ident, Constructor, [SplitTypePtr])] ->
   Expand ()
-forkEstablishConstructors sc vp dt ctors =
-  forkExpanderTask $ EstablishConstructors sc vp dt ctors
+forkEstablishConstructors scs vp dt ctors =
+  forkExpanderTask $ EstablishConstructors scs vp dt ctors
 
 forkInterpretMacroAction :: MacroDest -> MacroAction -> [Closure] -> Expand ()
 forkInterpretMacroAction dest act kont = do

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -495,9 +495,11 @@ getBody ptr =
   (view (expanderCompletedModBody . at ptr) <$> getState) >>=
   \case
     Nothing -> throwError $ InternalError "Incomplete module after expansion"
-    Just Done -> pure []
-    Just (Decl decl next) ->
-      (:) <$> getDecl decl <*> getBody next
+    Just NoDecls -> pure []
+    Just (Decl decl) ->
+      (:[]) <$> getDecl decl
+    Just (Decls l r) ->
+      (++) <$> getBody l <*> getBody r
 
 getDecl :: DeclPtr -> Expand CompleteDecl
 getDecl ptr =

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -37,10 +37,9 @@ data ExpanderTask
     -- ^ Waiting on var, binding, and definiens, destination, syntax to expand
   | AwaitingType SplitTypePtr [AfterTypeTask]
   | ExpandDeclTree DeclTreePtr Scope Syntax DeclValidityPtr
-    -- ^ The tree node to fill, the scope, the decls, and how to notify that all
-    -- the names have been bound.
-  | ExpandDependentDeclTree DeclTreePtr Scope Syntax DeclValidityPtr
-    -- ^ Depends on the binding of the names in DeclValidityPtr
+    -- ^ The tree node to fill, the scope, the decls, and the output environment.
+  | ExpandDependentDeclTree DeclTreePtr Syntax DeclValidityPtr
+    -- ^ The tree node to fill, the decls, and the input environment.
   | InterpretMacroAction MacroDest MacroAction [Closure]
   | ContinueMacroAction MacroDest Value [Closure]
   | EvalDefnAction Var Ident Phase SplitCorePtr
@@ -48,7 +47,7 @@ data ExpanderTask
     -- ^ The expression whose type should be generalized, and the place to put the resulting scheme
   | ExpandVar Ty SplitCorePtr Syntax Var
     -- ^ Expected type, destination, origin syntax, and variable to use if it's acceptable
-  | EstablishConstructors DeclValidityPtr Datatype [(Ident, Constructor, [SplitTypePtr])]
+  | EstablishConstructors Scope DeclValidityPtr Datatype [(Ident, Constructor, [SplitTypePtr])]
   | AwaitingPattern PatternPtr Ty SplitCorePtr Syntax
   deriving (Show)
 
@@ -92,13 +91,13 @@ instance ShortShow ExpanderTask where
   shortShow (AwaitingMacro dest t) = "(AwaitingMacro " ++ show dest ++ " " ++ shortShow t ++ ")"
   shortShow (AwaitingType tdest tasks) = "(AwaitingType " ++ show tdest ++ " " ++ show tasks ++ ")"
   shortShow (ExpandDeclTree _dest _sc stx ptr) = "(ExpandDeclTree " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
-  shortShow (ExpandDependentDeclTree _dest _sc stx ptr) = "(ExpandDependentDeclTree " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
+  shortShow (ExpandDependentDeclTree _dest stx ptr) = "(ExpandDependentDeclTree " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
   shortShow (InterpretMacroAction _dest act kont) = "(InterpretMacroAction " ++ show act ++ " " ++ show kont ++ ")"
   shortShow (ContinueMacroAction _dest value kont) = "(ContinueMacroAction " ++ show value ++ " " ++ show kont ++ ")"
   shortShow (EvalDefnAction var name phase _expr) = "(EvalDefnAction " ++ show var ++ " " ++ shortShow name ++ " " ++ show phase ++ ")"
   shortShow (GeneralizeType e _ _) = "(GeneralizeType " ++ show e ++ " _ _)"
   shortShow (ExpandVar t d x v) = "(ExpandVar " ++ show t ++ " " ++ show d ++ " " ++ show x ++ " " ++ show v ++ ")"
-  shortShow (EstablishConstructors _ dt _) = "(EstablishConstructors " ++ show dt ++ ")"
+  shortShow (EstablishConstructors _ _ dt _) = "(EstablishConstructors " ++ show dt ++ ")"
   shortShow (AwaitingPattern _ _ _ _) = "(AwaitingPattern _ _ _ _)"
 
 instance Pretty VarInfo ExpanderTask where

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -23,7 +23,7 @@ import Value
 data MacroDest
   = ExprDest Ty SplitCorePtr
   | TypeDest SplitTypePtr
-  | DeclTreeDest DeclTreePtr DeclValidityPtr
+  | DeclTreeDest DeclTreePtr DeclOutputScopesPtr
     -- ^ produced declaration tree, scopes introduced
   | PatternDest Ty Ty PatternPtr
     -- ^ expression type, scrutinee type, destination pointer
@@ -37,7 +37,7 @@ data ExpanderTask
   | AwaitingDefn Var Ident Binding SplitCorePtr Ty SplitCorePtr Syntax
     -- ^ Waiting on var, binding, and definiens, destination, syntax to expand
   | AwaitingType SplitTypePtr [AfterTypeTask]
-  | ExpandDeclForms DeclTreePtr ScopeSet DeclValidityPtr DeclValidityPtr Syntax
+  | ExpandDeclForms DeclTreePtr ScopeSet DeclOutputScopesPtr DeclOutputScopesPtr Syntax
     -- ^ The produced declaration tree, some already-introduced scopes which
     -- the syntax can already see, some to-be-introduced scopes which the will
     -- see, a destination for all the introduced scopes, including those by the
@@ -49,7 +49,7 @@ data ExpanderTask
     -- ^ The expression whose type should be generalized, and the place to put the resulting scheme
   | ExpandVar Ty SplitCorePtr Syntax Var
     -- ^ Expected type, destination, origin syntax, and variable to use if it's acceptable
-  | EstablishConstructors ScopeSet DeclValidityPtr Datatype [(Ident, Constructor, [SplitTypePtr])]
+  | EstablishConstructors ScopeSet DeclOutputScopesPtr Datatype [(Ident, Constructor, [SplitTypePtr])]
   | AwaitingPattern PatternPtr Ty SplitCorePtr Syntax
   deriving (Show)
 
@@ -92,7 +92,7 @@ instance ShortShow ExpanderTask where
     "(AwaitingDefn " ++ shortShow n ++ " " ++ shortShow stx ++ ")"
   shortShow (AwaitingMacro dest t) = "(AwaitingMacro " ++ show dest ++ " " ++ shortShow t ++ ")"
   shortShow (AwaitingType tdest tasks) = "(AwaitingType " ++ show tdest ++ " " ++ show tasks ++ ")"
-  shortShow (ExpandDeclForms _dest _scs waitingOn vp stx) = "(ExpandDeclForms _ " ++ show waitingOn ++ " " ++ show vp ++ " " ++ T.unpack (syntaxText stx) ++ ")"
+  shortShow (ExpandDeclForms _dest _scs waitingOn outScopesDest stx) = "(ExpandDeclForms _ " ++ show waitingOn ++ " " ++ show outScopesDest ++ " " ++ T.unpack (syntaxText stx) ++ ")"
   shortShow (InterpretMacroAction _dest act kont) = "(InterpretMacroAction " ++ show act ++ " " ++ show kont ++ ")"
   shortShow (ContinueMacroAction _dest value kont) = "(ContinueMacroAction " ++ show value ++ " " ++ show kont ++ ")"
   shortShow (EvalDefnAction var name phase _expr) = "(EvalDefnAction " ++ show var ++ " " ++ shortShow name ++ " " ++ show phase ++ ")"

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -23,7 +23,7 @@ import Value
 data MacroDest
   = ExprDest Ty SplitCorePtr
   | TypeDest SplitTypePtr
-  | ModBodyDest ModBodyPtr Scope DeclValidityPtr
+  | DeclTreeDest DeclTreePtr Scope DeclValidityPtr
   | PatternDest Ty Ty PatternPtr
     -- ^ expression type, scrutinee type, destination pointer
   deriving Show
@@ -36,10 +36,10 @@ data ExpanderTask
   | AwaitingDefn Var Ident Binding SplitCorePtr Ty SplitCorePtr Syntax
     -- ^ Waiting on var, binding, and definiens, destination, syntax to expand
   | AwaitingType SplitTypePtr [AfterTypeTask]
-  | ExpandModBody ModBodyPtr Scope Syntax DeclValidityPtr
+  | ExpandDeclTree DeclTreePtr Scope Syntax DeclValidityPtr
     -- ^ The tree node to fill, the scope, the decls, and how to notify that all
     -- the names have been bound.
-  | ExpandDependentModBody ModBodyPtr Scope Syntax DeclValidityPtr
+  | ExpandDependentDeclTree DeclTreePtr Scope Syntax DeclValidityPtr
     -- ^ Depends on the binding of the names in DeclValidityPtr
   | InterpretMacroAction MacroDest MacroAction [Closure]
   | ContinueMacroAction MacroDest Value [Closure]
@@ -91,8 +91,8 @@ instance ShortShow ExpanderTask where
     "(AwaitingDefn " ++ shortShow n ++ " " ++ shortShow stx ++ ")"
   shortShow (AwaitingMacro dest t) = "(AwaitingMacro " ++ show dest ++ " " ++ shortShow t ++ ")"
   shortShow (AwaitingType tdest tasks) = "(AwaitingType " ++ show tdest ++ " " ++ show tasks ++ ")"
-  shortShow (ExpandModBody _dest _sc stx ptr) = "(ExpandModBody " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
-  shortShow (ExpandDependentModBody _dest _sc stx ptr) = "(ExpandDependentModBody " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
+  shortShow (ExpandDeclTree _dest _sc stx ptr) = "(ExpandDeclTree " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
+  shortShow (ExpandDependentDeclTree _dest _sc stx ptr) = "(ExpandDependentDeclTree " ++ T.unpack (syntaxText stx) ++ " " ++ show ptr ++ ")"
   shortShow (InterpretMacroAction _dest act kont) = "(InterpretMacroAction " ++ show act ++ " " ++ show kont ++ ")"
   shortShow (ContinueMacroAction _dest value kont) = "(ContinueMacroAction " ++ show value ++ " " ++ show kont ++ ")"
   shortShow (EvalDefnAction var name phase _expr) = "(EvalDefnAction " ++ show var ++ " " ++ shortShow name ++ " " ++ show phase ++ ")"

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -215,7 +215,7 @@ newModBodyPtr :: IO ModBodyPtr
 newModBodyPtr = ModBodyPtr <$> newUnique
 
 
-data ModuleBodyF decl next = Done | Decl decl next
+data ModuleBodyF decl next = NoDecls | Decl decl | Decls next next
 
 data SplitModuleBody a = SplitModuleBody
   { _splitModuleRoot :: ModBodyPtr

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -25,10 +25,10 @@ module Module (
   , forExports_
   , ModulePtr
   , newModulePtr
-  , ModBodyPtr
-  , newModBodyPtr
-  , ModuleBodyF(..)
-  , SplitModuleBody(..)
+  , DeclTreePtr
+  , newDeclTreePtr
+  , DeclTreeF(..)
+  , SplitDeclTree(..)
   , DeclPtr
   , newDeclPtr
   , BindingTable
@@ -205,21 +205,24 @@ instance Bifunctor (Decl ty scheme) where
 instance (Phased decl, Phased expr) => Phased (Decl ty scheme decl expr) where
   shift i = bimap (shift i) (shift i)
 
-newtype ModBodyPtr = ModBodyPtr Unique
+newtype DeclTreePtr = DeclTreePtr Unique
   deriving (Eq, Ord)
 
-instance Show ModBodyPtr where
-  show (ModBodyPtr u) = "(ModBodyPtr " ++ show (hashUnique u) ++ ")"
+instance Show DeclTreePtr where
+  show (DeclTreePtr u) = "(DeclTreePtr " ++ show (hashUnique u) ++ ")"
 
-newModBodyPtr :: IO ModBodyPtr
-newModBodyPtr = ModBodyPtr <$> newUnique
+newDeclTreePtr :: IO DeclTreePtr
+newDeclTreePtr = DeclTreePtr <$> newUnique
 
 
-data ModuleBodyF decl next = NoDecls | Decl decl | Decls next next
+data DeclTreeF decl next
+  = DeclTreeLeaf
+  | DeclTreeAtom decl
+  | DeclTreeBranch next next
 
-data SplitModuleBody a = SplitModuleBody
-  { _splitModuleRoot :: ModBodyPtr
-  , _splitModuleDescendents :: Map ModBodyPtr (ModuleBodyF a ModBodyPtr)
+data SplitDeclTree a = SplitDeclTree
+  { _splitDeclTreeRoot :: DeclTreePtr
+  , _splitDeclTreeDescendents :: Map DeclTreePtr (DeclTreeF a DeclTreePtr)
   }
 
 makeLenses ''CompleteDecl

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -151,7 +151,7 @@ data Module f a = Module
 makeLenses ''Module
 
 
-newtype CompleteDecl = CompleteDecl { _completeDecl :: Decl Ty (Scheme Ty) CompleteDecl Core }
+newtype CompleteDecl = CompleteDecl { _completeDecl :: Decl Ty (Scheme Ty) [CompleteDecl] Core }
   deriving Show
 
 instance Phased CompleteDecl where

--- a/src/Module.hs
+++ b/src/Module.hs
@@ -35,6 +35,7 @@ module Module (
   ) where
 
 import Control.Lens
+import Control.Monad.IO.Class
 import Data.Functor
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -211,8 +212,8 @@ newtype DeclTreePtr = DeclTreePtr Unique
 instance Show DeclTreePtr where
   show (DeclTreePtr u) = "(DeclTreePtr " ++ show (hashUnique u) ++ ")"
 
-newDeclTreePtr :: IO DeclTreePtr
-newDeclTreePtr = DeclTreePtr <$> newUnique
+newDeclTreePtr :: MonadIO m => m DeclTreePtr
+newDeclTreePtr = DeclTreePtr <$> liftIO newUnique
 
 
 data DeclTreeF decl next

--- a/src/Phase.hs
+++ b/src/Phase.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Phase (Phase, phaseNum, runtime, prior, PhaseSpec(..), Phased(..)) where
+module Phase (Phase, phaseNum, runtime, prior, Phased(..)) where
 
 import Control.Lens
 import Numeric.Natural
@@ -13,9 +13,6 @@ makePrisms ''Phase
 
 instance ShortShow Phase where
   shortShow (Phase i) = "p" ++ show i
-
-data PhaseSpec = AllPhases | SpecificPhase !Phase
-makePrisms ''PhaseSpec
 
 runtime :: Phase
 runtime = Phase 0

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -241,6 +241,16 @@ instance Pretty VarInfo core => Pretty VarInfo (ScopedList core) where
 instance PrettyBinder VarInfo CompleteDecl where
   ppBind env (CompleteDecl d) = ppBind env d
 
+instance PrettyBinder VarInfo [CompleteDecl] where
+  ppBind env [] = (text "no-decls", env)
+  ppBind env [decl] = ppBind env decl
+  ppBind env decls =
+    let (docs, envs) = unzip $ fmap (ppBind env) decls
+        doc = align $ group $ vsep docs
+        env' = mconcat envs
+    in (text "group" <> doc, env')
+
+
 instance Pretty VarInfo (Scheme Ty) where
   pp env (Scheme 0 t) =
     pp env t

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -243,13 +243,13 @@ instance PrettyBinder VarInfo CompleteDecl where
 
 instance PrettyBinder VarInfo [CompleteDecl] where
   ppBind env decls = over _1 vsep
-                   $ foldr go (\e -> (mempty, e)) decls env
+                   $ foldr go (\e -> (mempty, e)) decls mempty
     where
       go :: CompleteDecl
          -> (Env Var () -> ([Doc VarInfo], Env Var ()))
          -> (Env Var () -> ([Doc VarInfo], Env Var ()))
-      go decl cc e = let (doc, e') = ppBind e decl
-                         (docs, e'') = cc e'
+      go decl cc e = let (doc, e') = ppBind (env <> e) decl
+                         (docs, e'') = cc (e <> e')
                      in (doc:docs, e'')
 
 

--- a/src/ScopeSet.hs
+++ b/src/ScopeSet.hs
@@ -6,6 +6,8 @@ module ScopeSet (
   -- * Scope Sets and their construction
     ScopeSet
   , empty
+  , singleScopeAtPhase
+  , singleUniversalScope
   -- * Queries
   , size
   , member
@@ -62,6 +64,12 @@ scopes p scs = view universalScopes scs `Set.union`
 
 size :: Phase -> ScopeSet -> Int
 size p = Set.size . scopes p
+
+singleScopeAtPhase :: Scope -> Phase -> ScopeSet
+singleScopeAtPhase sc p = insertAtPhase p sc mempty
+
+singleUniversalScope :: Scope -> ScopeSet
+singleUniversalScope sc = insertUniversally sc mempty
 
 insertAtPhase :: Phase -> Scope -> ScopeSet -> ScopeSet
 insertAtPhase p sc = set (phaseScopes . at p . non Set.empty . at sc)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -97,6 +97,22 @@ flipScope p = adjustScope go
 addScope' :: HasScopes a => a -> Scope -> a
 addScope' = adjustScope ScopeSet.insertUniversally
 
+addScopes :: HasScopes a => a -> ScopeSet -> a
+addScopes a0 scopeSet
+  = let a1 = addUniversalScopes a0 scopeSet
+        a2 = addSpecificScopes a1 scopeSet
+    in a2
+  where
+    addUniversalScopes :: HasScopes a => a -> ScopeSet -> a
+    addUniversalScopes =
+      foldlOf (to ScopeSet.contents . _1 . folded)
+              addScope'
+
+    addSpecificScopes :: HasScopes a => a -> ScopeSet -> a
+    addSpecificScopes =
+      ifoldlOf (to ScopeSet.contents .> _2 .> ifolded <. folded)
+               addScope
+
 
 syntaxE :: Syntax -> ExprF Syntax
 syntaxE (Syntax (Stx _ _ e)) = e

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -576,7 +576,7 @@ testFile f p = do
   mn <- moduleNameFromPath f
   ctx <- mkInitContext mn
   void $ execExpand initializeKernel ctx
-  (flip execExpand ctx $ completely $ do
+  (flip execExpand ctx $ do
     visit mn >> view expanderWorld <$> getState) >>=
     \case
       Left err -> assertFailure (T.unpack (pretty err))
@@ -598,7 +598,7 @@ testFileError f p = do
   mn <- moduleNameFromPath f
   ctx <- mkInitContext mn
   void $ execExpand initializeKernel ctx
-  (flip execExpand ctx $ completely $ do
+  (flip execExpand ctx $ do
     visit mn >> view expanderWorld <$> getState) >>=
     \case
       Left err | p err -> return ()

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -311,11 +311,13 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
               view moduleBody m & map (view completeDecl) &
               \case
                 [Import _,
-                 Meta [view completeDecl -> Define _ _ _ _],
+                 Meta [ view completeDecl -> Define _ _ _ _
+                      , view completeDecl -> Define _ _ _ _
+                      ],
                  DefineMacros [(_, _, _)],
                  Example _ _ ex] ->
                   assertAlphaEq "Example is signal" ex (Core (CoreSignal (Signal 1)))
-                _ -> assertFailure "Expected an import, a meta-def, a macro def, and an example"
+                _ -> assertFailure "Expected an import, two meta-defs, a macro def, and an example"
           )
         , ( "examples/imports-shifted-macro.kl"
           , \m _ ->

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -537,7 +537,7 @@ testExpander input spec = do
              initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
              inEarlierPhase $
                initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
-             addRootScope expr >>= addModuleScope >>= expandExpr
+             addRootScope expr >>= addModuleScope >>= fullyExpandExpr
       case c of
         Left err -> assertFailure . T.unpack . pretty $ err
         Right expanded ->
@@ -557,7 +557,7 @@ testExpansionFails input okp =
              initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
              inEarlierPhase $
                initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
-             expandExpr =<< addModuleScope =<< addRootScope expr
+             fullyExpandExpr =<< addModuleScope =<< addRootScope expr
 
       case c of
         Left err
@@ -576,7 +576,7 @@ testFile f p = do
   mn <- moduleNameFromPath f
   ctx <- mkInitContext mn
   void $ execExpand initializeKernel ctx
-  execExpand (visit mn >> view expanderWorld <$> getState) ctx >>=
+  execExpand (fullyVisit mn >> view expanderWorld <$> getState) ctx >>=
     \case
       Left err -> assertFailure (T.unpack (pretty err))
       Right w ->
@@ -597,7 +597,7 @@ testFileError f p = do
   mn <- moduleNameFromPath f
   ctx <- mkInitContext mn
   void $ execExpand initializeKernel ctx
-  execExpand (visit mn >> view expanderWorld <$> getState) ctx >>=
+  execExpand (fullyVisit mn >> view expanderWorld <$> getState) ctx >>=
     \case
       Left err | p err -> return ()
                | otherwise ->

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -311,7 +311,7 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
               view moduleBody m & map (view completeDecl) &
               \case
                 [Import _,
-                 Meta (view completeDecl -> Define _ _ _ _),
+                 Meta [view completeDecl -> Define _ _ _ _],
                  DefineMacros [(_, _, _)],
                  Example _ _ ex] ->
                   assertAlphaEq "Example is signal" ex (Core (CoreSignal (Signal 1)))


### PR DESCRIPTION
We want to allow macros running in a declaration context to be able to produce more than one declaration.

TODO:

- [x] Make ModuleBody a binary tree instead of a list
- [x] Adapt the task queue to support filling-in branches of that tree
- [x] Make sure all the names in the left branch are bound before expanding the right branch
- [x] Fix the failing tests
- [x] ~Add `no-decls` and `decls` primitives~ Added `group` directly
- [x] ~Implement the `group` macro in terms of `no-decls` and `decls`~
- [x] As a test, implement a macro which uses `group` to generate multiple declarations
- [x] Fix the `PrettyBinder VarInfo [CompleteDecl]` instance
- [x] Avoid using the word "environment" incorrectly