### PR TITLE
Add syntax for catchall pattern

### DIFF
--- a/examples/datatypes.golden
+++ b/examples/datatypes.golden
@@ -6,3 +6,6 @@
 #<closure> : (Nat → (Nat → Nat))
 (add1 (add1 (add1 (add1 (add1 (zero)))))) : Nat
 #<closure> : (Alphabet → Signal)
+#<closure> : (Alphabet → Bool)
+#true : Bool
+#false : Bool

--- a/examples/datatypes.kl
+++ b/examples/datatypes.kl
@@ -94,5 +94,21 @@
     [(ø) 27]
     [(å) 28])))
 
+(define vowel?
+  (lambda (letter)
+    (case letter
+      [(a) #true]
+      [(e) #true]
+      [(i) #true]
+      [(o) #true]
+      [(u) #true]
+      [(y) #true]
+      [(æ) #true]
+      [(ø) #true]
+      [(å) #true]
+      [(else x) #false])))
+(example vowel?)
+(example (vowel? (y)))
+(example (vowel? (x)))
 
 (export Nat zero add1)

--- a/examples/n-ary-app.kl
+++ b/examples/n-ary-app.kl
@@ -110,5 +110,5 @@
         >>= pure syntax-error syntax-case
         list-syntax cons-list-syntax empty-list-syntax replace-loc
         free-identifier=? bound-identifier=? log
-        datatype case)
+        datatype case else)
 

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -434,7 +434,7 @@ initializeKernel = do
 
     addExprPrimitive :: Text -> (Ty -> SplitCorePtr -> Syntax -> Expand ()) -> Expand ()
     addExprPrimitive name impl = do
-      let val = EPrimMacro impl
+      let val = EPrimExprMacro impl
       b <- freshBinding
       bind b val
       addToKernel name runtime b
@@ -789,7 +789,7 @@ expandOneForm prob stx
       b <- resolve =<< addRootScope ident
       v <- getEValue b
       case v of
-        EPrimMacro impl -> do
+        EPrimExprMacro impl -> do
           (t, dest) <- requireExpressionCtx stx prob
           impl t dest stx
           saveExprType dest t

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -205,7 +205,7 @@ newtype ExpansionEnv = ExpansionEnv (Map.Map Binding EValue)
   deriving (Semigroup, Monoid)
 
 data EValue
-  = EPrimMacro (Ty -> SplitCorePtr -> Syntax -> Expand ()) -- ^ For special forms
+  = EPrimExprMacro (Ty -> SplitCorePtr -> Syntax -> Expand ()) -- ^ For special forms
   | EPrimTypeMacro (SplitTypePtr -> Syntax -> Expand ()) -- ^ For type-level special forms
   | EPrimModuleMacro (Syntax -> Expand ())
   | EPrimDeclMacro (DeclTreePtr -> DeclOutputScopesPtr -> Syntax -> Expand ())

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -209,6 +209,7 @@ data EValue
   | EPrimTypeMacro (SplitTypePtr -> Syntax -> Expand ()) -- ^ For type-level special forms
   | EPrimModuleMacro (Syntax -> Expand ())
   | EPrimDeclMacro (DeclTreePtr -> DeclOutputScopesPtr -> Syntax -> Expand ())
+  | EPrimPatternMacro (Ty -> Ty -> PatternPtr -> Syntax -> Expand ())
   | EVarMacro !Var -- ^ For bound variables (the Unique is the binding site of the var)
   | ETypeVar !Natural -- ^ For bound type variables (user-written Skolem variables or in datatype definitions)
   | EUserMacro !MacroVar -- ^ For user-written macros

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -41,6 +41,8 @@ module Expander.Primitives
   , arrowType
   , baseType
   , macroType
+  -- * Pattern primitives
+  , elsePattern
   -- * Module primitives
   , makeModule
   -- * Local primitives
@@ -480,6 +482,20 @@ makeModule expandDeclForms stx =
 
       pure ()
 
+--------------
+-- Patterns --
+--------------
+
+type PatternPrim = Ty -> Ty -> PatternPtr -> Syntax -> Expand ()
+
+elsePattern :: PatternPrim
+elsePattern _exprTy scrutTy dest stx = do
+  Stx _ _ (_ :: Syntax, var) <- mustHaveEntries stx
+  ty <- trivialScheme scrutTy
+  (sc, x, v) <- prepareVar var
+  modifyState $ set (expanderPatternBinders . at dest) $
+    Just [(sc, x, v, ty)]
+  linkPattern dest $ AnyConstructor x v
 
 -------------
 -- Helpers --


### PR DESCRIPTION
This previously had no syntax, so it couldn't be used and wasn't tested.

This is another prerequisite to #36.