### PR TITLE
KLISTERPATH

### DIFF
--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -527,10 +527,6 @@ primImportModule dest outScopesDest importStx = do
   linkDeclOutputScopes outScopesDest (ScopeSet.singleUniversalScope sc)
   where
     importSpec :: Syntax -> Expand ImportSpec
-    importSpec (Syntax (Stx scs srcloc (String s))) =
-      ImportModule . Stx scs srcloc <$> liftIO (moduleNameFromLocatedPath srcloc (T.unpack s))
-    importSpec (Syntax (Stx scs srcloc (Id "kernel"))) =
-      return $ ImportModule (Stx scs srcloc (KernelName kernelName))
     importSpec stx@(Syntax (Stx _ _ (List elts)))
       | (Syntax (Stx _ _ (Id "only")) : spec : names) <- elts = do
           subSpec <- importSpec spec
@@ -546,7 +542,7 @@ primImportModule dest outScopesDest importStx = do
         Stx _ _ p <- mustBeIdent prefix
         return $ PrefixImports subSpec p
       | otherwise = throwError $ NotImportSpec stx
-    importSpec other = throwError $ NotImportSpec other
+    importSpec modStx = ImportModule <$> mustBeModName modStx
     getRename s = do
       Stx _ _ (old', new') <- mustHaveEntries s
       old <- mustBeIdent old'

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -11,6 +11,7 @@ import Core
 import Datatype
 import Evaluator
 import Expander.Task
+import KlisterPath
 import Phase
 import Pretty
 
@@ -40,6 +41,7 @@ data ExpansionErr
   | MacroEvaluationError Phase EvalError
   | ValueNotMacro Value
   | ValueNotSyntax Value
+  | ImportError KlisterPathError
   | InternalError String
   | NoSuchFile String
   | NotExported Ident Phase
@@ -131,6 +133,7 @@ instance Pretty VarInfo ExpansionErr where
     group $ hang 4 $ vsep [ pp env loc <> text ":"
                           , text "Not available at phase" <+> pp env p <> text ":" <+> pp env x
                           ]
+  pp _env (ImportError err) = ppKlisterPathError err
   pp _env (InternalError str) =
     text "Internal error during expansion! This is a bug in the implementation." <> line <> string str
   pp _env (ReaderError txt) =

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -21,6 +21,7 @@ module Expander.Monad
   , constructorInfo
   , currentEnv
   , currentPhase
+  , klisterPath
   , currentBindingLevel
   , currentTransformerEnv
   , datatypeInfo
@@ -165,6 +166,7 @@ import Expander.Error
 import Expander.Task
 import Module
 import ModuleName
+import KlisterPath
 import PartialCore
 import PartialType
 import Phase
@@ -234,10 +236,12 @@ data ExpanderLocal = ExpanderLocal
   , _expanderPhase :: !Phase
   , _expanderBindingLevels :: !(Map Phase BindingLevel)
   , _expanderVarTypes :: TypeContext Var SchemePtr
+  , _expanderKlisterPath :: !KlisterPath
   }
 
 mkInitContext :: ModuleName -> IO ExpanderContext
 mkInitContext mn = do
+  klisterPath <- getKlisterPath
   st <- newIORef initExpanderState
   return $ ExpanderContext { _expanderState = st
                            , _expanderLocal = ExpanderLocal
@@ -245,6 +249,7 @@ mkInitContext mn = do
                              , _expanderPhase = runtime
                              , _expanderBindingLevels = Map.empty
                              , _expanderVarTypes = mempty
+                             , _expanderKlisterPath = klisterPath
                              }
                            }
 
@@ -349,6 +354,10 @@ withLocal localData = Expand . local (set expanderLocal localData) . runExpand
 
 currentPhase :: Expand Phase
 currentPhase = Expand $ view (expanderLocal . expanderPhase) <$> ask
+
+klisterPath :: Expand KlisterPath
+klisterPath =
+  Expand $ view (expanderLocal . expanderKlisterPath) <$> ask
 
 inPhase :: Phase -> Expand a -> Expand a
 inPhase p act = Expand $ local (over (expanderLocal . expanderPhase) (const p)) $ runExpand act

--- a/src/Expander/Syntax.hs
+++ b/src/Expander/Syntax.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -11,6 +12,7 @@ import qualified Data.Text as T
 
 import Expander.Error
 import Expander.Monad
+import KlisterPath
 import ModuleName
 import Syntax
 
@@ -41,8 +43,12 @@ mustBeString (Syntax (Stx scs srcloc (String s))) = return (Stx scs srcloc s)
 mustBeString other = throwError (NotString other)
 
 mustBeModName :: Syntax -> Expand (Stx ModuleName)
-mustBeModName (Syntax (Stx scs srcloc (String s))) =
-  Stx scs srcloc <$> liftIO (moduleNameFromLocatedPath srcloc (T.unpack s))
+mustBeModName (Syntax (Stx scs srcloc (String s))) = do
+  kPath <- klisterPath
+  liftIO (moduleNameFromLocatedPath kPath srcloc (T.unpack s)) >>=
+    \case
+      Left err -> throwError (ImportError err)
+      Right path -> pure $ Stx scs srcloc path
 -- TODO use hygiene here instead
 mustBeModName (Syntax (Stx scs srcloc (Id "kernel"))) =
   return (Stx scs srcloc (KernelName kernelName))

--- a/src/KlisterPath.hs
+++ b/src/KlisterPath.hs
@@ -1,0 +1,91 @@
+{-
+Module           : KlisterPath
+Description      : Implementation of $KLISTERPATH
+Copyright        : (c) Klister Collaborators 2020
+License          : See GH#55
+Maintainer       : Langston Barrett <langston@galois.com>
+Stability        : provisional
+-}
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+
+module KlisterPath
+  ( KlisterPath
+  , KlisterPathError(..)
+  , ppKlisterPathError
+  , getKlisterPath
+  , makeKlisterPath
+  , importFromKlisterPath
+  ) where
+
+import Data.Functor ((<&>))
+import qualified Data.Set as Set
+import Data.Set (Set)
+import qualified Data.Text.Prettyprint.Doc as PP
+import Data.Traversable (for)
+import System.Directory (canonicalizePath, listDirectory)
+import System.FilePath.Posix ((</>))
+import System.Environment (lookupEnv)
+
+-- | A list of directories to search for modules
+--
+-- Invariant: All paths are canonical.
+newtype KlisterPath = KlisterPath { unKlisterPath :: Set FilePath }
+  deriving (Monoid, Semigroup, Show)
+
+makeKlisterPath :: Set FilePath -> IO KlisterPath
+makeKlisterPath paths =
+  KlisterPath . Set.fromList <$>
+    mapM canonicalizePath (Set.toList paths)
+
+-- | Fetch the Klister path from the environment variable @KLISTERPATH@.
+getKlisterPath :: IO KlisterPath
+getKlisterPath =
+  makeKlisterPath =<<
+    maybe Set.empty (Set.fromList . (split ':')) <$>
+      lookupEnv "KLISTERPATH"
+  where
+    -- How is this not in the Prelude...?
+    split :: Eq a => a -> [a] -> [[a]]
+    split _ [] = []
+    split d s = x : split d (drop 1 y)
+      where (x, y) = span (/= d) s
+
+data KlisterPathError
+  = ModuleNotFound String
+  | TooManyFound String [FilePath]
+  deriving (Eq, Show)
+
+ppKlisterPathError :: KlisterPathError -> PP.Doc ann
+ppKlisterPathError =
+  \case
+    ModuleNotFound modName ->
+      PP.pretty $ "Module not found on $KLISTERPATH: " <> modName
+    TooManyFound modName found ->
+      PP.vsep $
+        [ PP.pretty $
+            "Ambiguous module name: " <> modName
+        , PP.pretty "Candidates:"
+        , PP.vsep $ map PP.pretty found
+        ]
+
+findInKlisterPath ::
+  KlisterPath {- ^ Path to search -} ->
+  String {- ^ Module to find -} ->
+  IO (Set FilePath) {- ^ Candidates found -}
+findInKlisterPath (KlisterPath paths) moduleName =
+  Set.fromList . concat <$>
+    (for (Set.toList paths) $ \path ->
+      map (path </>) . filter (== moduleName) <$> listDirectory path)
+
+importFromKlisterPath ::
+  KlisterPath {- ^ Path to search -} ->
+  String {- ^ Module to find -} ->
+  IO (Either KlisterPathError FilePath)
+importFromKlisterPath klisterPath moduleName =
+  findInKlisterPath klisterPath moduleName <&> Set.toList <&>
+    \case
+      [found] -> Right found
+      [] -> Left (ModuleNotFound moduleName)
+      tooMany -> Left (TooManyFound moduleName tooMany)

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -27,6 +27,7 @@ import Env
 import Evaluator (EvalResult(..), EvalError(..), TypeError(..))
 import Module
 import ModuleName
+import KlisterPath
 import Phase
 import Scope
 import ScopeSet
@@ -586,3 +587,6 @@ instance Pretty VarInfo ScopeSet where
       ppMap m =
         group (vsep [group (viaShow k <+> text "↦" <> line <> v) | (k, v) <- Map.toList m])
 
+
+instance Pretty VarInfo KlisterPathError where
+  pp _ = ppKlisterPathError


### PR DESCRIPTION
Fixes #56 

Here's an example of it finding the import properly:
```bash
$ cat examples/path.kl

#lang kernel
(import "in-other-dir.kl")
(example works)

$ cat examples/path/in-other-dir.kl

#lang kernel

(define works (lambda (x) x))

$ unset KLISTERPATH

$ cabal run klister -- run examples/path.kl
Up to date
Module not found on $KLISTERPATH: in-other-dir.kl
ExitFailure 1

$ export KLISTERPATH=$PWD/examples/path

$ cabal run klister -- run examples/path.kl
Up to date
Unknown: #[path.kl:3.10-3.15]<works>
ExitFailure 1
```