### PR TITLE
make parens optional for builtin types and constructors

### DIFF
--- a/examples/bool.kl
+++ b/examples/bool.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 
 (define not

--- a/examples/contract.kl
+++ b/examples/contract.kl
@@ -1,7 +1,7 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 [import "defun.kl"]
 [import "bool.kl"]
-[import [shift "n-ary-app.kl" 1]]
+[import [shift "prelude.kl" 1]]
 [import [shift "defun.kl"1]]
 
 (meta

--- a/examples/datatype-import.kl
+++ b/examples/datatype-import.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "datatypes.kl")
 (import "defun.kl")

--- a/examples/datatype-macro.kl
+++ b/examples/datatype-macro.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 (import "defun.kl")
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "lispy-do.kl" 1))
 (import (shift "let.kl" 1))
 (import (shift "quasiquote.kl" 1))

--- a/examples/define-syntax-rule.kl
+++ b/examples/define-syntax-rule.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "do.kl" 1))
 (import (shift "list-syntax.kl" 1))
 (import (shift "quasiquote.kl" 1))

--- a/examples/defun.kl
+++ b/examples/defun.kl
@@ -1,5 +1,5 @@
-#lang "n-ary-app.kl"
-[import [shift "n-ary-app.kl" 1]]
+#lang "prelude.kl"
+[import [shift "prelude.kl" 1]]
 
 
 (define-macros

--- a/examples/do.kl
+++ b/examples/do.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import (shift "let.kl" 1))
 

--- a/examples/failing-examples/bound-vs-free.kl
+++ b/examples/failing-examples/bound-vs-free.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import (shift "do.kl" 1))
 (import (shift "bool.kl" 1))

--- a/examples/free-identifier-case-test.kl
+++ b/examples/free-identifier-case-test.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "free-identifier-case.kl" 1))
 
 (define-macros

--- a/examples/free-identifier-case.kl
+++ b/examples/free-identifier-case.kl
@@ -1,7 +1,7 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "let.kl")
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 
 (meta

--- a/examples/fun-exports-test.kl
+++ b/examples/fun-exports-test.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
-(import (shift "n-ary-app.kl" 1))
-(import (shift "n-ary-app.kl" 2))
+#lang "prelude.kl"
+(import (shift "prelude.kl" 1))
+(import (shift "prelude.kl" 2))
 (import "fun-exports.kl")
 
 (example a)

--- a/examples/hygiene.kl
+++ b/examples/hygiene.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-[import [shift "n-ary-app.kl" 1]]
+[import [shift "prelude.kl" 1]]
 [import [shift "quasiquote.kl" 1]]
 
 [define fun [lambda (x y) x]]

--- a/examples/import-list-and-do.kl
+++ b/examples/import-list-and-do.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "list-datatype.kl")
 

--- a/examples/lambda-case.kl
+++ b/examples/lambda-case.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 
 (define-macros

--- a/examples/lang.kl
+++ b/examples/lang.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 [define f [lambda (x y z) y]]
 

--- a/examples/let.kl
+++ b/examples/let.kl
@@ -1,7 +1,7 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "quasiquote.kl")
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "list-syntax.kl" 1))
 (import (shift "quasiquote.kl" 1))
 

--- a/examples/lispy-do.kl
+++ b/examples/lispy-do.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import (shift "let.kl" 1))
 

--- a/examples/list-datatype.kl
+++ b/examples/list-datatype.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "defun.kl")
 

--- a/examples/list-syntax.kl
+++ b/examples/list-syntax.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "defun.kl")
 

--- a/examples/macro-body-shift.kl
+++ b/examples/macro-body-shift.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-[import [shift "n-ary-app.kl" 1]]
+[import [shift "prelude.kl" 1]]
 
 [define fun [lambda [x] [lambda [y] [lambda [z] y]]]]
 

--- a/examples/mcond-test.kl
+++ b/examples/mcond-test.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "mcond.kl" 1))
 
 (define-macros

--- a/examples/mcond.kl
+++ b/examples/mcond.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 
 (define-macros

--- a/examples/meta-macro.kl
+++ b/examples/meta-macro.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import (shift "let.kl" 1))
 

--- a/examples/pair-datatype.kl
+++ b/examples/pair-datatype.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "lambda-case.kl")
 

--- a/examples/pmatch.kl
+++ b/examples/pmatch.kl
@@ -1,9 +1,9 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 (import "defun.kl")
 (import "pair-datatype.kl")
 (import "list-datatype.kl")
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 
 (import (shift "quasiquote.kl" 1))
 (import (shift "defun.kl" 1))

--- a/examples/quasiquote-syntax-test.kl
+++ b/examples/quasiquote-syntax-test.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 [import "quasiquote.kl"]
 

--- a/examples/quasiquote.kl
+++ b/examples/quasiquote.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-[import [shift "n-ary-app.kl" 1]]
+[import [shift "prelude.kl" 1]]
 [import [shift "defun.kl" 1]]
 
 

--- a/examples/syntax.kl
+++ b/examples/syntax.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "defun.kl")
 (import "do.kl")

--- a/examples/temporaries-test.kl
+++ b/examples/temporaries-test.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "lispy-do.kl" 1))
 (import (shift "list-datatype.kl" 1))
 (import (shift "pair-datatype.kl" 1))

--- a/examples/temporaries.kl
+++ b/examples/temporaries.kl
@@ -1,4 +1,4 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
 (import "lispy-do.kl")
 (import "list-datatype.kl")

--- a/examples/unknown-type.kl
+++ b/examples/unknown-type.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import "pair-datatype.kl")
 

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -11,14 +11,14 @@
           (lambda (prob)
             (case prob
               [(declaration)  (pure '(example (the (m) (m))))]
-              [(type)         (pure '(Bool))]
-              [(expression t) (pure '(true))]
-              [(pattern)      (pure '(unit))]))))]))
+              [(type)         (pure 'Bool)]
+              [(expression t) (pure 'true)]
+              [(pattern)      (pure 'unit)]))))]))
 
 (m)
 
-(example (case (unit)
-           ((m) (true))))
+(example (case unit
+           ((m) true)))
 
 (define-macro (mega-const e)
   (>>= (which-problem)
@@ -31,7 +31,7 @@
                          (mega-const ,e)))]
                [(else x) (pure e)])]))))
 
-(example (the (-> (Bool) (Bool) (Bool) (Bool) (Unit)) (mega-const (unit))))
+(example (the (-> Bool Bool Bool Bool Unit) (mega-const unit)))
 
 (datatype (Both A) (both A A))
 

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -1,6 +1,6 @@
-#lang "n-ary-app.kl"
+#lang "prelude.kl"
 
-(import (shift "n-ary-app.kl" 1))
+(import (shift "prelude.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import "quasiquote.kl")
 (import "define-syntax-rule.kl")

--- a/stdlib/builtins.kl
+++ b/stdlib/builtins.kl
@@ -1,0 +1,32 @@
+#lang kernel
+
+-- Allow e.g. unit instead of (unit)
+
+[import [shift kernel 1]]
+
+(meta
+  (define optional-parens
+    (lambda (symbol)
+      (lambda (stx)
+        (syntax-case stx
+          [(ident x)
+           (pure (list-syntax (symbol) stx))]
+          [(cons x xs)
+           (pure (cons-list-syntax symbol xs stx))])))))
+
+-- TODO: wrap 'datatype' so that parentheses are also optional for
+-- the nullary types and constructors it creates
+(define-macros
+  ([my-Unit (optional-parens 'Unit)]
+   [my-unit (optional-parens 'unit)]
+   [my-Bool (optional-parens 'Bool)]
+   [my-true (optional-parens 'true)]
+   [my-false (optional-parens 'false)]
+   [my-nothing (optional-parens 'nothing)]))
+
+(export (rename ([my-Unit Unit] [my-unit unit]
+                 [my-Bool Bool] [my-true true] [my-false false]
+                 [my-nothing nothing])
+                my-Unit my-unit
+                my-Bool my-true my-false
+                Maybe my-nothing just))

--- a/stdlib/n-ary-app.kl
+++ b/stdlib/n-ary-app.kl
@@ -109,47 +109,5 @@
                                           (cons-list-syntax 'my-arrow args stx))
                                         stx))])]))]))
 
-(meta
-  (define optional-parens
-    (lambda (symbol)
-      (lambda (stx)
-        (syntax-case stx
-          [(ident x)
-           (pure (list-syntax (symbol) stx))]
-          [(cons x xs)
-           (pure (cons-list-syntax symbol xs stx))])))))
-
--- TODO: wrap 'datatype' so that parentheses are also optional for
--- the nullary types and constructors it creates
-(define-macros
-  ([my-Unit (optional-parens 'Unit)]
-   [my-unit (optional-parens 'unit)]
-   [my-Bool (optional-parens 'Bool)]
-   [my-true (optional-parens 'true)]
-   [my-false (optional-parens 'false)]
-   [my-nothing (optional-parens 'nothing)]))
-
-(export (rename ([my-arrow ->]
-                 [my-Unit Unit] [my-unit unit]
-                 [my-Bool Bool] [my-true true] [my-false false]
-                 [my-nothing nothing])
-                my-arrow
-                my-Unit my-unit
-                my-Bool my-true my-false
-                my-nothing))
-(export #%module #%app
-        lambda define example define-macros quote meta
-        the Syntax Macro
-        with-unknown-type
-        if
-        error
-        let flet
-        import export
-        Macro
-        which-problem declaration type expression pattern
-        >>= pure syntax-error syntax-case
-        Syntax list-syntax cons-list-syntax empty-list-syntax replace-loc
-        free-identifier=? bound-identifier=? log make-introducer
-        ScopeAction flip add remove
-        Maybe just
-        datatype case type-case else)
+(export (rename ([my-arrow ->]) my-arrow))
+(export if #%app lambda flet)

--- a/stdlib/n-ary-app.kl
+++ b/stdlib/n-ary-app.kl
@@ -2,7 +2,7 @@
 
 -- N-ary function abstraction and application
 
-[import [shift (only kernel cons-list-syntax lambda pure quote syntax-case list-syntax export import) 1]]
+[import [shift kernel 1]]
 
 (define-macros
   ([if
@@ -109,43 +109,23 @@
                                           (cons-list-syntax 'my-arrow args stx))
                                         stx))])]))]))
 
+(meta
+  (define optional-parens
+    (lambda (symbol)
+      (lambda (stx)
+        (syntax-case stx
+          [(ident x)
+           (pure (list-syntax (symbol) stx))]
+          [(cons x xs)
+           (pure (cons-list-syntax symbol xs stx))])))))
+
 (define-macros
-  ([my-Unit (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('Unit) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'Unit xs stx))]))]
-   [my-unit (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('unit) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'unit xs stx))]))]
-   [my-Bool (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('Bool) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'Bool xs stx))]))]
-   [my-true (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('true) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'true xs stx))]))]
-   [my-false (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('false) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'false xs stx))]))]
-   [my-nothing (lambda (stx)
-              (syntax-case stx
-                [(ident x)
-                 (pure (list-syntax ('nothing) stx))]
-                [(cons x xs)
-                 (pure (cons-list-syntax 'nothing xs stx))]))]))
+  ([my-Unit (optional-parens 'Unit)]
+   [my-unit (optional-parens 'unit)]
+   [my-Bool (optional-parens 'Bool)]
+   [my-true (optional-parens 'true)]
+   [my-false (optional-parens 'false)]
+   [my-nothing (optional-parens 'nothing)]))
 
 (export (rename ([my-arrow ->]
                  [my-Unit Unit] [my-unit unit]

--- a/stdlib/n-ary-app.kl
+++ b/stdlib/n-ary-app.kl
@@ -109,23 +109,65 @@
                                           (cons-list-syntax 'my-arrow args stx))
                                         stx))])]))]))
 
-(export (rename ([my-arrow ->]) my-arrow))
+(define-macros
+  ([my-Unit (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('Unit) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'Unit xs stx))]))]
+   [my-unit (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('unit) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'unit xs stx))]))]
+   [my-Bool (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('Bool) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'Bool xs stx))]))]
+   [my-true (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('true) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'true xs stx))]))]
+   [my-false (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('false) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'false xs stx))]))]
+   [my-nothing (lambda (stx)
+              (syntax-case stx
+                [(ident x)
+                 (pure (list-syntax ('nothing) stx))]
+                [(cons x xs)
+                 (pure (cons-list-syntax 'nothing xs stx))]))]))
+
+(export (rename ([my-arrow ->]
+                 [my-Unit Unit] [my-unit unit]
+                 [my-Bool Bool] [my-true true] [my-false false]
+                 [my-nothing nothing])
+                my-arrow
+                my-Unit my-unit
+                my-Bool my-true my-false
+                my-nothing))
 (export #%module #%app
         lambda define example define-macros quote meta
         the Syntax Macro
         with-unknown-type
-        if true false
+        if
         error
         let flet
         import export
         Macro
         which-problem declaration type expression pattern
-        Unit unit
-        Bool true false
         >>= pure syntax-error syntax-case
         Syntax list-syntax cons-list-syntax empty-list-syntax replace-loc
         free-identifier=? bound-identifier=? log make-introducer
-        Unit unit
         ScopeAction flip add remove
-        Maybe just nothing
+        Maybe just
         datatype case type-case else)

--- a/stdlib/n-ary-app.kl
+++ b/stdlib/n-ary-app.kl
@@ -119,6 +119,8 @@
           [(cons x xs)
            (pure (cons-list-syntax symbol xs stx))])))))
 
+-- TODO: wrap 'datatype' so that parentheses are also optional for
+-- the nullary types and constructors it creates
 (define-macros
   ([my-Unit (optional-parens 'Unit)]
    [my-unit (optional-parens 'unit)]

--- a/stdlib/prelude.kl
+++ b/stdlib/prelude.kl
@@ -1,22 +1,78 @@
-#lang "n-ary-app.kl"
+#lang kernel
+
+(import "builtins.kl")
+(import "n-ary-app.kl")
 
 [define id [lambda (x) x]]
 [define const [lambda (x y) x]]
 [define compose [lambda (f g x) (f (g x))]]
 (define compose* (flet (comp (f g x) (f (g x))) comp))
 
-(export #%module #%app
-        lambda define example define-macros quote meta
-        if true false
-        error
-        let flet
-        import export
-        >>= pure syntax-error syntax-case
-        list-syntax cons-list-syntax empty-list-syntax replace-loc
-        free-identifier=? bound-identifier=? log
-        datatype case else
+(export -- primitive types
+        Syntax
+        Signal
+        -> 
+        Macro
+        Type
 
-        -- non-#lang
+        -- primitive datatypes
+        ScopeAction flip add remove
+        Unit unit
+        Bool true false
+        Problem declaration expression type pattern
+        Maybe nothing just
+
+        -- primitive module macros
+        #%module
+
+        -- primitive declaration macros
+        define
+        datatype
+        define-macros
+        example
+        import
+        export
+        meta
+        group
+
+        -- primitive expression macros
+        oops
+        error
+        the
+        let
+        flet
+        lambda
+        #%app
+        pure
+        >>=
+        syntax-error
+        send-signal
+        wait-signal
+        bound-identifier=?
+        free-identifier=?
+        quote
+        ident
+        ident-syntax
+        empty-list-syntax
+        cons-list-syntax
+        list-syntax
+        replace-loc
+        syntax-case
+        let-syntax
+        log
+        make-introducer
+        which-problem
+        case
+        type-case
+
+        -- primitive patterns
+        else
+
+        -- primitive universal macros
+        with-unknown-type
+
+        -- non-primitives
+        if
         id
         const
         compose


### PR DESCRIPTION
Ideally I would also wrap `datatype` so that the nullary types and constructors it generates also have optional parentheses, but I only did builtins for now because that's all we need to make the extended abstract's example look nice.