### PR TITLE
deep-matching on syntax objects

### DIFF
--- a/examples/define-syntax-rule.golden
+++ b/examples/define-syntax-rule.golden
@@ -1,1 +1,3 @@
-#[define-syntax-rule.kl:88.33-88.36]<bar> : Syntax
+#[define-syntax-rule.kl:41.10-41.26]<(m1 foo bar baz)> : Syntax
+#[define-syntax-rule.kl:42.14-42.17]<foo> : Syntax
+#[define-syntax-rule.kl:109.33-109.36]<bar> : Syntax

--- a/examples/define-syntax-rule.golden
+++ b/examples/define-syntax-rule.golden
@@ -1,1 +1,1 @@
-#[define-syntax-rule.kl:46.33-46.36]<bar> : Syntax
+#[define-syntax-rule.kl:88.33-88.36]<bar> : Syntax

--- a/examples/define-syntax-rule.kl
+++ b/examples/define-syntax-rule.kl
@@ -1,10 +1,12 @@
 #lang "prelude.kl"
 
 (import (shift "prelude.kl" 1))
+(import (shift "defun.kl" 1))
 (import (shift "do.kl" 1))
 (import (shift "list-syntax.kl" 1))
 (import (shift "quasiquote.kl" 1))
 (import (shift "syntax.kl" 1))
+(import (shift "temporaries.kl" 1))
 
 (define-macros
   ((define-macro
@@ -19,29 +21,69 @@
                                       ((list ,pattern)
                                        ,body)))))))))))))))
 
+-- pattern is a tree of variable names
+-- template is an expression containing those variable names
+-- stx is used for constructing syntax objects
+-- cc is a monadic continuation which we call with an unwrapping function and
+--   an unquoted template. The unquote template is a version of the input
+--   template in which each variable var found in the pattern has been replaced
+--   with (unquote var); it thus makes sense to wrap it in a quasiquote. The
+--   unwrapping function takes as input a variable name and a body, and
+--   generates code which matches on that variable name, deconstructing it into
+--   the shape described by the pattern and bying the pattern's variables so
+--   that they are available in the body (which is also a syntax object).
+(meta
+  (defun bind-vars (pattern template stx cc)
+    (syntax-case pattern
+      [(ident arg)
+       (do (template <- (replace-identifier
+                          arg
+                          (list-syntax ('unquote arg) stx)
+                          template))
+           (cc (lambda (var body)
+                 `(let [,arg ,var]
+                    ,body))
+               template))]
+      [(cons car-pattern cdr-pattern)
+       (bind-vars car-pattern template stx
+         (lambda (car-unwrap template)
+           (bind-vars cdr-pattern template stx
+             (lambda (cdr-unwrap template)
+               (do (car-var <- (make-temporary 'car-var))
+                   (cdr-var <- (make-temporary 'cdr-var))
+                   (cc (lambda (var body)
+                         `(syntax-case ,var
+                            [(cons ,car-var ,cdr-var)
+                             ,(cdr-unwrap cdr-var
+                                (car-unwrap car-var
+                                  body))]))
+                       template))))))]
+      [(list ())
+       (cc (lambda (var body)
+             `(syntax-case ,var
+                [(list ())
+                 ,body]))
+           template)])))
+
 (define-macros
-  ((define-syntax-rule
-     (lambda (stx)
-       (syntax-case stx
-         ((list (_ pattern template))
-          (syntax-case pattern
-           ((cons macro-name args)
-            (do (unquoted-template <- (foldlM (lambda (t arg)
-                                                (replace-identifier
-                                                  arg
-                                                  (list-syntax ('unquote arg) stx)
-                                                  t))
-                                              template
-                                              args))
-                (quasiquoted-template <- (pure (list-syntax ('quasiquote unquoted-template) stx)))
-                (pure `(define-macros
-                         ((,macro-name (lambda (stx)
-                                         (syntax-case stx
-                                          ((list ,pattern)
-                                           (pure ,quasiquoted-template)))))))))))))))))
+  ([define-syntax-rule
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ macro-args-pattern template))
+         (syntax-case macro-args-pattern
+           [(cons macro-name args-pattern)
+            (bind-vars macro-args-pattern template stx
+              (lambda (unwrap unquoted-template)
+                (let [quasiquoted-template
+                      (list-syntax ('quasiquote unquoted-template) stx)]
+                  (pure `(define-macros
+                           ([,macro-name
+                             (lambda (stx)
+                               ,(unwrap 'stx
+                                  `(pure ,quasiquoted-template)))]))))))])]))]))
 
 (define-syntax-rule (lambda2 x y body)
-  (lambda (x y) body))
+                      (lambda (x y) body))
 
 (example ((lambda2 x y y) 'foo 'bar))  -- 'bar
 

--- a/examples/define-syntax-rule.kl
+++ b/examples/define-syntax-rule.kl
@@ -8,18 +8,39 @@
 (import (shift "syntax.kl" 1))
 (import (shift "temporaries.kl" 1))
 
+-- (define-macro my-macro
+--   (lambda (stx) ...))
+-- or
+-- (define-macro (my-macro arg1 arg2 arg3)
+--   ...)
 (define-macros
-  ((define-macro
-     (lambda (stx)
-       (syntax-case stx
-         ((list (_ pattern body))
-          (syntax-case pattern
-           ((cons macro-name args)
+  ([define-macro
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ pattern body))
+         (syntax-case pattern
+           [(ident macro-name)
             (pure `(define-macros
-                     ((,macro-name (lambda (stx)
-                                     (syntax-case stx
-                                      ((list ,pattern)
-                                       ,body)))))))))))))))
+                     ([,macro-name
+                       ,body])))]
+           [(cons macro-name args)
+            (pure `(define-macros
+                     ([,macro-name
+                       (lambda (stx)
+                         (syntax-case stx
+                           [(list ,pattern)
+                            ,body]))])))])]))]))
+
+(define-macro m1
+  (lambda (stx)
+    (pure `(,'quote ,stx))))
+
+(define-macro (m2 arg)
+  (pure `(,'quote ,arg)))
+
+(example (m1 foo bar baz))  -- '(m1 foo bar baz)
+(example (m2 foo))          -- 'foo
+
 
 -- pattern is a tree of variable names
 -- template is an expression containing those variable names

--- a/examples/syntax.golden
+++ b/examples/syntax.golden
@@ -1,0 +1,11 @@
+(just #[quasiquote.kl:56.57-56.60]<(Signal 1 Signal 2 Signal 3 Signal 4)>) : (Maybe Syntax)
+(just #[quasiquote.kl:56.57-56.60]<(Signal 1 (Signal 2 Signal 3) Signal 4)>) : (Maybe Syntax)
+(nothing) : (Maybe Syntax)
+#[quasiquote.kl:56.57-56.60]<(Signal 1 Signal 2 Signal 3 Signal 4)> : Syntax
+#[quasiquote.kl:49.63-49.66]
+ <(other (Signal 1 (Signal 2 Signal 3) Signal 4 Signal 5))> : Syntax
+#[quasiquote.kl:56.57-56.60]<(Signal 1 Signal 2 Signal 3 Signal 4)> : Syntax
+#[quasiquote.kl:49.63-49.66]
+ <(car Signal 1 cdr ((Signal 2 Signal 3) Signal 4 Signal 5))> : Syntax
+#[quasiquote.kl:49.63-49.66]
+ <(other (Signal 1 (Signal 2 Signal 3) Signal 4 Signal 5))> : Syntax

--- a/examples/syntax.kl
+++ b/examples/syntax.kl
@@ -9,10 +9,9 @@
 (import "pmatch.kl")
 (import "quasiquote.kl")
 
-(define-macros
-  ([tree
-    (lambda (stx)
-      (error '(tree is only intended to be used as a pattern)))]))
+(define tree
+  (lambda (_)
+    (error '(tree is only intended to be used as a pattern))))
 
 (meta
   -- (is-tree-pattern '(tree foo))
@@ -259,5 +258,5 @@
 --- replace-identifier is only available at phase 0.
 
 
-(export (rename ([my-syntax-case syntax-case]) syntax-case))
-(export tree syntax-pmatch replace-identifier)
+--(export (rename ([my-syntax-case syntax-case]) syntax-case))
+(export tree syntax-pmatch replace-identifier my-syntax-case)

--- a/examples/syntax.kl
+++ b/examples/syntax.kl
@@ -1,7 +1,242 @@
 #lang "prelude.kl"
 
+(import (shift "prelude.kl" 1))
+(import (shift "do.kl" 1))
+(import (shift "free-identifier-case.kl" 1))
+(import (shift "quasiquote.kl" 1))
 (import "defun.kl")
 (import "do.kl")
+(import "pmatch.kl")
+(import "quasiquote.kl")
+
+(define-macros
+  ([tree
+    (lambda (stx)
+      (error '(tree is only intended to be used as a pattern)))]))
+
+(meta
+  -- (is-tree-pattern '(tree foo))
+  -- =>
+  -- (pure (just 'foo))
+  --
+  -- (is-tree-pattern '(foo bar))
+  -- =>
+  -- nothing
+  --
+  -- (is-tree-pattern 'else)
+  -- =>
+  -- nothing
+  (define is-tree-pattern
+    (lambda (pattern)
+      (syntax-case pattern
+        [(list (tree_ x))
+         (syntax-case tree_
+           [(ident tree_)
+            (free-identifier-case tree_
+              [tree
+               (pure (just x))]
+              [(else _)
+               (pure nothing)])]
+           [_
+            (pure nothing)])]
+        [_
+         (pure nothing)])))
+
+  -- (is-else-pattern '(else foo))
+  -- =>
+  -- (pure (just 'foo))
+  --
+  -- (is-else-pattern '(foo bar))
+  -- =>
+  -- nothing
+  --
+  -- (is-else-pattern 'else)
+  -- =>
+  -- nothing
+  (define is-else-pattern
+    (lambda (pattern)
+      (syntax-case pattern
+        [(list (else_ x))
+         (syntax-case else_
+           [(ident else_)
+            (free-identifier-case else_
+              [else
+               (pure (just x))]
+              [(else _)
+               (pure nothing)])]
+           [_
+            (pure nothing)])]
+        [_
+         (pure nothing)]))))
+
+
+(define-macros
+  ([match-tree
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ scrutinee pattern body))
+         (syntax-case pattern
+           [(ident x)
+            (pure `(let [,x ,scrutinee]
+                     (just ,body)))]
+           [(list ())
+            (pure `(syntax-case ,scrutinee
+                     [(list ())
+                      (just ,body)]
+                     [_
+                      nothing]))]
+           [(cons car-pattern cdr-pattern)
+            (pure `(syntax-case ,scrutinee
+                     [(cons car-scrutinee cdr-scrutinee)
+                      (pmatch (match-tree car-scrutinee ,car-pattern
+                                (match-tree cdr-scrutinee ,cdr-pattern
+                                  ,body))
+                        [(just (just r))
+                         (just r)]
+                        [(else _)
+                         nothing])]
+                     [_
+                      nothing]))])]))]))
+
+-- (just '(1 2 3 4))
+(example
+  (match-tree '(1 (2 3) 4)
+               (a (b c) d)
+    `(,a ,b ,c ,d)))
+
+-- (just '(1 (2 3) 4))
+(example
+  (match-tree '(1 (2 3) 4)
+               (a b c)
+    `(,a ,b ,c)))
+
+-- (nothing)
+(example
+  (match-tree '(1 (2 3) 4)
+               (a b)
+    `(,a ,b)))
+
+
+(define-macros
+  ([syntax-pmatch
+    (lambda (stx)
+      (syntax-case stx
+        [(cons _ scrutinee-cases)
+         (syntax-case scrutinee-cases
+           [(cons scrutinee-expr cases)
+            (pure `(let [scrutinee ,scrutinee-expr]
+                     (syntax-pmatch-aux scrutinee ,cases)))])]))]
+   [syntax-pmatch-aux
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ scrutinee cases))
+         (syntax-case cases
+           [(list ())
+            (pure `(error ',scrutinee))]
+           [(cons pattern-body cases)
+            (syntax-case pattern-body
+              [(list [pattern body])
+               (do (is-else <- (is-else-pattern pattern))
+                   (case is-else
+                     [(just x)
+                      (pure `(let [,x ,scrutinee]
+                               ,body))]
+                     [(nothing)
+                      (pure `(case (match-tree ,scrutinee ,pattern ,body)
+                               [(just r)
+                                r]
+                               [(nothing)
+                                (syntax-pmatch-aux ,scrutinee ,cases)]))]))])])]))]))
+
+-- `(1 2 3 4)
+(example
+  (syntax-pmatch '(1 (2 3) 4)
+    [(a b)
+     'nope]
+    [(a (b c) d)
+     `(,a ,b ,c ,d)]
+    [(else x)
+     'nope]))
+
+-- `(other (1 (2 3) 4 5))
+(example
+  (syntax-pmatch '(1 (2 3) 4 5)
+    [(a b)
+     'nope]
+    [(a (b c) d)
+     'nope]
+    [(else x)
+     `(other ,x)]))
+
+
+(define-macros
+  ([my-syntax-case
+    (lambda (stx)
+      (syntax-case stx
+        [(cons _ scrutinee-and-cases)
+         (syntax-case scrutinee-and-cases
+           [(cons scrutinee-expr cases)
+            (pure `(let [scrutinee ,scrutinee-expr]
+                     (my-syntax-case-aux scrutinee ,cases)))])]))]
+   [my-syntax-case-aux
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ scrutinee cases))
+         (syntax-case cases
+           [(list ())
+            -- let the original syntax-case pick the error message
+            (pure `(syntax-case ,scrutinee))]
+           [(cons pattern-body cases)
+            (syntax-case pattern-body
+              [(list [pattern body])
+               (do (is-tree <- (is-tree-pattern pattern))
+                   (is-else <- (is-else-pattern pattern))
+                   (case is-tree
+                     [(just tree-pattern)
+                      (pure `(syntax-pmatch ,scrutinee
+                               [,tree-pattern
+                                ,body]
+                               [(else _)
+                                (my-syntax-case-aux ,scrutinee ,cases)]))]
+                     [(nothing)
+                      (case is-else
+                        [(just x)
+                         (pure `(let [,x ,scrutinee]
+                                  ,body))]
+                        [(nothing)
+                         (pure `(syntax-case ,scrutinee
+                                  [,pattern ,body]
+                                  [_
+                                   (my-syntax-case-aux ,scrutinee ,cases)]))])]))])])]))]))
+
+-- `(1 2 3 4)
+(example
+  (my-syntax-case '(1 (2 3) 4)
+    [(list (a b))
+     'nope]
+    [(tree (a (b c) d))
+     `(,a ,b ,c ,d)]
+    [(else x)
+     'nope]))
+
+-- `(car 1 cdr ((2 3) 4 5))
+(example
+  (my-syntax-case '(1 (2 3) 4 5)
+    [(tree (a (b c) d))
+     'nope]
+    [(cons car cdr)
+     `(car ,car cdr ,cdr)]))
+
+-- `(other ,(1 (2 3) 4 5))
+(example
+  (my-syntax-case '(1 (2 3) 4 5)
+    [(tree (a (b c) d))
+     'nope]
+    [(list (a b))
+     'nope]
+    [(else other)
+     `(other ,other)]))
+
 
 -- (replace-identifier 'y 'x '(x y z z y)
 -- =>
@@ -20,7 +255,9 @@
     (_
      (pure haystack))))
 
--- can't be tested here because we'd need to define a macro but
--- replace-identifier is only available at phase 0.
+--- can't be tested here because we'd need to define a macro but
+--- replace-identifier is only available at phase 0.
 
-(export replace-identifier)
+
+(export (rename ([my-syntax-case syntax-case]) syntax-case))
+(export tree syntax-pmatch replace-identifier)

--- a/examples/which-problem.golden
+++ b/examples/which-problem.golden
@@ -1,6 +1,0 @@
-(true) : Bool
-(true) : Bool
-#<closure> : (Bool → (Bool → (Bool → (Bool → Unit))))
-#<closure> : (Bool → (Bool → (Bool → (Bool → Unit))))
-(both #<closure> #<closure>) : ∀α β γ. (Both (α → (β → (γ → Syntax))))
-(both #<closure> #<closure>) : ∀α β γ. (Both (α → (β → (γ → Syntax))))

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -35,14 +35,8 @@
 
 (example (the (-> Bool Bool Bool Bool Unit) (mega-const unit)))
 
-(define-macros
-  ([llet (lambda (stx)
-          (syntax-case stx
-            [(list (_ binding body))
-             (syntax-case binding
-               [(list (name def))
-                (pure (quasiquote/loc stx
-                        ((lambda (,name) ,body) ,def)))])]))]))
+(define-syntax-rule (llet (x value) body)
+  ((lambda (x) body) value))
 
 (example (llet (x (mega-const unit)) (the (-> Bool Bool Bool Bool Unit) x)))
 


### PR DESCRIPTION
`pmatch` is very convenient for deep-matching on datatypes, here is a version for syntax objects. That should make writing macros more pleasant!