### PR TITLE
Strings

### DIFF
--- a/examples/string.golden
+++ b/examples/string.golden
@@ -1,1 +1,4 @@
 "hello world" : String
+"hello world" : String
+(true) : Bool
+(false) : Bool

--- a/examples/string.golden
+++ b/examples/string.golden
@@ -1,0 +1,1 @@
+"hello world" : String

--- a/examples/string.kl
+++ b/examples/string.kl
@@ -1,0 +1,4 @@
+#lang kernel
+
+(example "hello world")
+

--- a/examples/string.kl
+++ b/examples/string.kl
@@ -2,3 +2,8 @@
 
 (example "hello world")
 
+(example ((string-append "hello ") "world"))
+
+(example ((string=? ((string-append "hello") " world")) "hello world"))
+
+(example ((string=? ((string-append "hello") "world")) "hello world"))

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -112,6 +112,7 @@ data CoreF typePat pat core
   | CoreApp core core
   | CoreCtor Constructor [core] -- ^ Constructor application
   | CoreDataCase SrcLoc core [(pat, core)]
+  | CoreString Text
   | CoreError core
   | CorePure core                       -- :: a -> Macro a
   | CoreBind core core                  -- :: Macro a -> (a -> Macro b) -> Macro b
@@ -157,6 +158,8 @@ mapCoreF _f _g h (CoreCtor ctor args) =
   CoreCtor ctor (map h args)
 mapCoreF _f g h (CoreDataCase loc scrut cases) =
   CoreDataCase loc (h scrut) [(g pat, h c) | (pat, c) <- cases]
+mapCoreF _f _g _h (CoreString str) =
+  CoreString str
 mapCoreF _f _g h (CoreError msg) =
   CoreError (h msg)
 mapCoreF _f _g h (CorePure core) =
@@ -213,6 +216,8 @@ traverseCoreF _f _g h (CoreCtor ctor args) =
   CoreCtor ctor <$> traverse h args
 traverseCoreF _f g h (CoreDataCase loc scrut cases) =
   CoreDataCase loc <$> h scrut <*> for cases \ (pat, c) -> (,) <$> g pat <*> h c
+traverseCoreF _f _g _h (CoreString str) =
+  pure $ CoreString str
 traverseCoreF _f _g h (CoreError msg) =
   CoreError <$> h msg
 traverseCoreF _f _g h (CorePure core) =
@@ -469,6 +474,8 @@ instance (ShortShow typePat, ShortShow pat, ShortShow core) =>
    ++ " "
    ++ intercalate ", " (map shortShow cases)
    ++ ")"
+  shortShow (CoreString str)
+    = "(String " ++ show str ++ ")"
   shortShow (CoreError what)
     = "(Error "
    ++ shortShow what

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -123,6 +123,7 @@ eval (Core (CoreCtor c args)) =
 eval (Core (CoreDataCase loc scrut cases)) = do
   value <- eval scrut
   doDataCase loc value cases
+eval (Core (CoreString str)) = pure (ValueString str)
 eval (Core (CoreError what)) = do
   msg <- evalAsSyntax what
   throwError $ EvalErrorUser msg

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -1059,7 +1059,10 @@ expandOneForm prob stx
             unify dest (Ty TSignal) t
             expandLiteralSignal dest s
             saveExprType dest t
-          String s -> expandLiteralString dest s
+          String s -> do
+            unify dest (Ty TString) t
+            expandLiteralString dest s
+            saveExprType dest t
           Id _ -> error "Impossible happened - identifiers are identifier-headed!"
 
 
@@ -1101,8 +1104,8 @@ expandLiteralSignal :: SplitCorePtr -> Signal -> Expand ()
 expandLiteralSignal dest signal = linkExpr dest (CoreSignal signal)
 
 expandLiteralString :: SplitCorePtr -> Text -> Expand ()
-expandLiteralString _dest str =
-  throwError $ InternalError $ "Strings are not valid expressions yet: " ++ show str
+expandLiteralString dest str = do
+  linkExpr dest (CoreString str)
 
 data MacroOutput
   = StuckOnSignal Signal [Closure]

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -124,6 +124,7 @@ module Expander.Monad
   , expanderKernelExports
   , expanderKernelDatatypes
   , expanderKernelConstructors
+  , expanderKernelValues
   , expanderModuleExports
   , expanderModuleImports
   , expanderModuleName
@@ -283,6 +284,7 @@ data ExpanderState = ExpanderState
   , _expanderKernelExports :: !Exports
   , _expanderKernelDatatypes :: !(Map Datatype DatatypeInfo)
   , _expanderKernelConstructors :: !(Map Constructor (ConstructorInfo Ty))
+  , _expanderKernelValues :: !(Env Var (SchemePtr, Value))
   , _expanderDeclOutputScopes :: !(Map DeclOutputScopesPtr ScopeSet)
   , _expanderCurrentEnvs :: !(Map Phase (Env Var Value))
   , _expanderCurrentTransformerEnvs :: !(Map Phase (Env MacroVar Value))
@@ -320,6 +322,7 @@ initExpanderState = ExpanderState
   , _expanderKernelExports = noExports
   , _expanderKernelDatatypes = mempty
   , _expanderKernelConstructors = mempty
+  , _expanderKernelValues = mempty
   , _expanderDeclOutputScopes = Map.empty
   , _expanderCurrentEnvs = Map.empty
   , _expanderCurrentTransformerEnvs = Map.empty

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -158,6 +158,7 @@ generalizeType ty = do
       [MetaPtr] -> TyF Ty ->
       StateT (Natural, Map MetaPtr Natural) Expand (TyF Ty)
     genVars _ TSyntax = pure TSyntax
+    genVars _ TString = pure TString
     genVars _ TSignal = pure TSignal
     genVars vars (TFun dom ran) =
       TFun <$> genTyVars vars dom <*> genTyVars vars ran
@@ -208,6 +209,7 @@ unifyWithBlame blame depth t1 t2 = do
     -- Rigid-rigid
     unify' TType TType = pure ()
     unify' TSyntax TSyntax = pure ()
+    unify' TString TString = pure ()
     unify' TSignal TSignal = pure ()
     unify' (TFun a c) (TFun b d) = unifyWithBlame blame (depth + 1) b a >> unifyWithBlame blame (depth + 1) c d
     unify' (TMacro a) (TMacro b) = unifyWithBlame blame (depth + 1) a b

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -129,6 +129,7 @@ instance (PrettyBinder VarInfo typePat, PrettyBinder VarInfo pat, Pretty VarInfo
                             pp (env <> env') rhs])
             cases
          ]
+  pp _env (CoreString str) = text (T.pack (show str))
   pp env (CoreError what) =
     text "error" <+> pp env what
   pp env (CorePure arg) =
@@ -312,6 +313,7 @@ typeVarNames =
 instance Pretty VarInfo a => Pretty VarInfo (TyF a) where
   pp _ TSyntax = text "Syntax"
   pp _ TSignal = text "Signal"
+  pp _ TString = text "String"
   pp env (TFun a b) =
     parens $ align $ group $ vsep [pp env a <+> text "→", pp env b]
   pp env (TMacro a) = parens (text "Macro" <+> align (pp env a))
@@ -486,6 +488,7 @@ instance Pretty VarInfo Value where
     text (view (constructorName . constructorNameText) c) <+>
     align (group (vsep (map (pp env) args)))
   pp _env (ValueType ptr) = text "#t<" <> viaShow ptr <> text ">"
+  pp _env (ValueString str) = text (T.pack (show str))
 
 instance Pretty VarInfo MacroAction where
   pp env (MacroActionPure v) =

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -28,6 +28,7 @@ instance Show MetaPtr where
 data TyF t
   = TSyntax
   | TSignal
+  | TString
   | TFun t t
   | TMacro t
   | TType

--- a/src/Value.hs
+++ b/src/Value.hs
@@ -41,6 +41,7 @@ data Value
   | ValueSignal Signal
   | ValueCtor Constructor [Value]
   | ValueType Ty
+  | ValueString Text
 
 instance Show Value where
   show _ = "Value..."
@@ -59,6 +60,7 @@ valueText (ValueCtor c args) =
   "(" <> view (constructorName . constructorNameText) c <> " " <>
   T.intercalate " " (map valueText args) <> ")"
 valueText (ValueType ptr) = "#t<" <> T.pack (show ptr) <> ">"
+valueText (ValueString str) = T.pack (show str)
 
 -- | Find a simple description that is suitable for inclusion in error messages.
 describeVal :: Value -> Text
@@ -69,6 +71,7 @@ describeVal (ValueSignal _) = "signal"
 describeVal (ValueCtor c _args) =
   view (constructorName . constructorNameText) c
 describeVal (ValueType _) = "type"
+describeVal (ValueString _) = "string"
 
 data FOClosure = FOClosure
   { _closureEnv   :: VEnv


### PR DESCRIPTION
This adds string literals and a bit of infrastructure for primitive values implemented in Haskell.

I'd like to have strings be overloaded - something like expanding `"foo"` into `(#%string "foo")` a la `#%app`, but that can always be added as an extension of this version.