### PR TITLE
Syntax support for strings

### DIFF
--- a/examples/let.golden
+++ b/examples/let.golden
@@ -1,2 +1,2 @@
 #[let.kl:27.20-27.24]<five> : Syntax
-#[quasiquote.kl:56.57-56.60]<(five two)> : Syntax
+#[quasiquote.kl:59.57-59.60]<(five two)> : Syntax

--- a/examples/let.golden
+++ b/examples/let.golden
@@ -1,2 +1,2 @@
 #[let.kl:27.20-27.24]<five> : Syntax
-#[quasiquote.kl:59.57-59.60]<(five two)> : Syntax
+#[let.kl:33.15-33.22]<(five two)> : Syntax

--- a/examples/quasiquote-syntax-test.golden
+++ b/examples/quasiquote-syntax-test.golden
@@ -1,8 +1,8 @@
 #[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
 #[quasiquote-syntax-test.kl:8.11-8.16]<thing> : Syntax
 #[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
-#[quasiquote.kl:49.63-49.66]<(thing)> : Syntax
-#[quasiquote.kl:56.57-56.60]<(nothing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(list-syntax (nothing thing) thing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(list-syntax (nothing thing ()) thing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(thing nothing thing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(thing)> : Syntax
+#[quasiquote.kl:59.57-59.60]<(nothing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing) thing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing ()) thing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(thing nothing thing)> : Syntax

--- a/examples/quasiquote-syntax-test.golden
+++ b/examples/quasiquote-syntax-test.golden
@@ -1,8 +1,8 @@
 #[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
 #[quasiquote-syntax-test.kl:8.11-8.16]<thing> : Syntax
 #[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
-#[quasiquote.kl:52.63-52.66]<(thing)> : Syntax
-#[quasiquote.kl:59.57-59.60]<(nothing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing) thing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing ()) thing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(thing nothing thing)> : Syntax
+#[quasiquote-syntax-test.kl:11.11-11.18]<(thing)> : Syntax
+#[quasiquote-syntax-test.kl:12.11-12.19]<(nothing)> : Syntax
+#[quasiquote-syntax-test.kl:14.11-14.45]<(list-syntax (nothing thing) thing)> : Syntax
+#[quasiquote-syntax-test.kl:16.11-16.48]<(list-syntax (nothing thing ()) thing)> : Syntax
+#[quasiquote-syntax-test.kl:18.11-18.31]<(thing nothing thing)> : Syntax

--- a/examples/quasiquote.golden
+++ b/examples/quasiquote.golden
@@ -1,9 +1,9 @@
-#[quasiquote.kl:67.22-67.29]<nothing> : Syntax
-#[quasiquote.kl:70.22-70.27]<thing> : Syntax
-#[quasiquote.kl:67.22-67.29]<nothing> : Syntax
-#[quasiquote.kl:49.63-49.66]<(thing)> : Syntax
-#[quasiquote.kl:56.57-56.60]<(nothing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(list-syntax (nothing thing) thing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(list-syntax (nothing thing ()) thing)> : Syntax
-#[quasiquote.kl:49.63-49.66]<(thing nothing thing)> : Syntax
-#[quasiquote.kl:67.22-67.29]<(thing nothing)> : Syntax
+#[quasiquote.kl:70.22-70.29]<nothing> : Syntax
+#[quasiquote.kl:73.22-73.27]<thing> : Syntax
+#[quasiquote.kl:70.22-70.29]<nothing> : Syntax
+#[quasiquote.kl:52.63-52.66]<(thing)> : Syntax
+#[quasiquote.kl:59.57-59.60]<(nothing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing) thing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing ()) thing)> : Syntax
+#[quasiquote.kl:52.63-52.66]<(thing nothing thing)> : Syntax
+#[quasiquote.kl:70.22-70.29]<(thing nothing)> : Syntax

--- a/examples/quasiquote.golden
+++ b/examples/quasiquote.golden
@@ -1,9 +1,9 @@
 #[quasiquote.kl:70.22-70.29]<nothing> : Syntax
 #[quasiquote.kl:73.22-73.27]<thing> : Syntax
 #[quasiquote.kl:70.22-70.29]<nothing> : Syntax
-#[quasiquote.kl:52.63-52.66]<(thing)> : Syntax
-#[quasiquote.kl:59.57-59.60]<(nothing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing) thing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(list-syntax (nothing thing ()) thing)> : Syntax
-#[quasiquote.kl:52.63-52.66]<(thing nothing thing)> : Syntax
+#[quasiquote.kl:76.22-76.29]<(thing)> : Syntax
+#[quasiquote.kl:77.22-77.39]<(nothing)> : Syntax
+#[quasiquote.kl:79.22-79.65]<(list-syntax (nothing thing) thing)> : Syntax
+#[quasiquote.kl:81.22-81.68]<(list-syntax (nothing thing ()) thing)> : Syntax
+#[quasiquote.kl:83.22-83.51]<(thing nothing thing)> : Syntax
 #[quasiquote.kl:70.22-70.29]<(thing nothing)> : Syntax

--- a/examples/quasiquote.kl
+++ b/examples/quasiquote.kl
@@ -49,14 +49,14 @@
                                                       (list-syntax ('quasiquote s)
                                                                    s))
                                                     e)
-                                        (list-syntax ('quote 'foo) 'foo))
+                                        (list-syntax ('quote (replace-loc e 'foo)) 'foo))
                                       e)]]]]]
               [_ [pure
                   (list-syntax ('list-syntax
                                   (map-syntax (lambda (s)
                                                 (list-syntax ('quasiquote s) s))
                                               e)
-                                  (list-syntax ('quote 'foo) 'foo))
+                                  (list-syntax ('quote (replace-loc e 'foo)) 'foo))
                                 e)]])])]
         [_ (syntax-error [list-syntax [[quote "bad syntax"] stx] stx] stx)])]])]
 

--- a/examples/quasiquote.kl
+++ b/examples/quasiquote.kl
@@ -24,6 +24,9 @@
            [[ident x]
             [pure [list-syntax [[quote quote] x]
                                x]]]
+           [[string str]
+            [pure [list-syntax [[quote quote] (string-syntax str e)]
+                               e]]]
            [()
             [pure
              [list-syntax [[quote empty-list-syntax]

--- a/examples/string-syntax.golden
+++ b/examples/string-syntax.golden
@@ -1,0 +1,1 @@
+"hihi" : String

--- a/examples/string-syntax.kl
+++ b/examples/string-syntax.kl
@@ -1,0 +1,16 @@
+#lang "prelude.kl"
+(import (shift "prelude.kl" 1))
+(import (shift "quasiquote.kl" 1))
+
+(define-macros
+  ([gotta-be-string
+    (lambda (stx)
+      (syntax-case stx
+        [(list (_ s))
+          (syntax-case s
+            [(string str) (pure (string-syntax (string-append str str) s))]
+            [_ (syntax-error (quasiquote/loc s "bad syntax"))])]
+        [_ (syntax-error (quasiquote/loc stx "bad syntax"))]))]))
+
+(example (gotta-be-string "hi"))
+

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -66,6 +66,7 @@ instance Phased TypePattern where
 
 data SyntaxPattern
   = SyntaxPatternIdentifier Ident Var
+  | SyntaxPatternString Ident Var
   | SyntaxPatternEmpty
   | SyntaxPatternCons Ident Var Ident Var
   | SyntaxPatternList [(Ident, Var)]
@@ -101,6 +102,14 @@ data ScopedList core = ScopedList
   deriving (Eq, Functor, Foldable, Show, Traversable)
 makeLenses ''ScopedList
 
+data ScopedString core = ScopedString
+  { _scopedString      :: core
+  , _scopedStringScope :: core
+  }
+  deriving (Eq, Functor, Foldable, Show, Traversable)
+makeLenses ''ScopedString
+
+
 data HowEq = Free | Bound
   deriving (Eq, Show)
 
@@ -132,6 +141,7 @@ data CoreF typePat pat core
   | CoreEmpty (ScopedEmpty core)
   | CoreCons (ScopedCons core)
   | CoreList (ScopedList core)
+  | CoreStringSyntax (ScopedString core)
   | CoreReplaceLoc core core
   | CoreTypeCase SrcLoc core [(typePat, core)]
   deriving (Eq, Functor, Foldable, Show, Traversable)
@@ -196,6 +206,8 @@ mapCoreF _f _g h (CoreCons args) =
   CoreCons (fmap h args)
 mapCoreF _f _g h (CoreList args) =
   CoreList (fmap h args)
+mapCoreF _f _g h (CoreStringSyntax str) =
+  CoreStringSyntax (fmap h str)
 mapCoreF _f _g h (CoreReplaceLoc src dest) =
   CoreReplaceLoc (h src) (h dest)
 mapCoreF f _g h (CoreTypeCase loc scrut cases) =
@@ -254,6 +266,8 @@ traverseCoreF _f _g h (CoreCons args) =
   CoreCons <$> traverse h args
 traverseCoreF _f _g h (CoreList args) =
   CoreList <$> traverse h args
+traverseCoreF _f _g h (CoreStringSyntax arg) =
+  CoreStringSyntax <$> traverse h arg
 traverseCoreF _f _g h (CoreReplaceLoc src dest) =
   CoreReplaceLoc <$> (h src) <*> (h dest)
 traverseCoreF f _g h (CoreTypeCase loc scrut cases) =
@@ -544,6 +558,10 @@ instance (ShortShow typePat, ShortShow pat, ShortShow core) =>
     = "(List "
    ++ shortShow scopedVec
    ++ ")"
+  shortShow (CoreStringSyntax scopedStr)
+    = "(StringSyntax "
+   ++ shortShow scopedStr
+   ++ ")"
   shortShow (CoreReplaceLoc loc stx)
     = "(ReplaceLoc "
    ++ shortShow loc ++ " "
@@ -576,6 +594,7 @@ instance ShortShow TypePattern where
 
 instance ShortShow SyntaxPattern where
   shortShow (SyntaxPatternIdentifier _ x) = shortShow x
+  shortShow (SyntaxPatternString _ x) = "(String " ++ shortShow x ++ ")"
   shortShow SyntaxPatternEmpty = "Empty"
   shortShow (SyntaxPatternCons _ x _ xs)
     = "(Cons "
@@ -617,6 +636,14 @@ instance ShortShow core => ShortShow (ScopedList core) where
   shortShow (ScopedList elements scope)
     = "(ScopedList "
    ++ shortShow elements
+   ++ " "
+   ++ shortShow scope
+   ++ ")"
+
+instance ShortShow core => ShortShow (ScopedString core) where
+  shortShow (ScopedString str scope)
+    = "(ScopedStringSyntax "
+   ++ shortShow str
    ++ " "
    ++ shortShow scope
    ++ ")"

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -383,6 +383,7 @@ initializeKernel = do
     typePrims :: [(Text, (SplitTypePtr -> Syntax -> Expand (), TypePatternPtr -> Syntax -> Expand ()))]
     typePrims =
       [ ("Syntax", Prims.baseType TSyntax)
+      , ("String", Prims.baseType TString)
       , ("Signal", Prims.baseType TSignal)
       , ("->", Prims.arrowType)
       , ("Macro", Prims.macroType)
@@ -457,6 +458,7 @@ initializeKernel = do
       , ("empty-list-syntax", Prims.emptyListSyntax)
       , ("cons-list-syntax", Prims.consListSyntax)
       , ("list-syntax", Prims.listSyntax)
+      , ("string-syntax", Prims.stringSyntax)
       , ("replace-loc", Prims.replaceLoc)
       , ("syntax-case", Prims.syntaxCase)
       , ("let-syntax", Prims.letSyntax)

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -171,6 +171,7 @@ instance (PrettyBinder VarInfo typePat, PrettyBinder VarInfo pat, Pretty VarInfo
   pp env (CoreEmpty e) = pp env e
   pp env (CoreCons e) = pp env e
   pp env (CoreList e) = pp env e
+  pp env (CoreStringSyntax s) = pp env s
   pp env (CoreReplaceLoc loc stx) =
     group $ hang 2 $ vsep [ text "replace-loc"
                           , pp env loc
@@ -231,6 +232,8 @@ instance PrettyBinder VarInfo ConstructorPattern where
 instance PrettyBinder VarInfo SyntaxPattern where
   ppBind _env (SyntaxPatternIdentifier ident@(Stx _ _ x) v) =
     (annotate (BindingSite v) (text x), Env.singleton v ident ())
+  ppBind _env (SyntaxPatternString ident@(Stx _ _ x) v) =
+    (parens $ text "string" <+> annotate (BindingSite v) (text x), Env.singleton v ident ())
   ppBind _env SyntaxPatternEmpty =
     (text "()", Env.empty)
   ppBind _env (SyntaxPatternCons ida@(Stx _ _ xa) va idd@(Stx _ _ xd) vd) =
@@ -267,6 +270,12 @@ instance Pretty VarInfo core => Pretty VarInfo (ScopedList core) where
   pp env xs =
     vec (hsep $ map (pp env) (view scopedListElements xs)) <>
     angles (pp env (view scopedListScope xs))
+
+instance Pretty VarInfo core => Pretty VarInfo (ScopedString core) where
+  pp env s =
+    pp env (view scopedString s) <>
+    angles (pp env (view scopedStringScope s))
+
 
 instance PrettyBinder VarInfo CompleteDecl where
   ppBind env (CompleteDecl d) = ppBind env d

--- a/stdlib/prelude.kl
+++ b/stdlib/prelude.kl
@@ -14,6 +14,7 @@
         -> 
         Macro
         Type
+        String string-append string=?
 
         -- primitive datatypes
         ScopeAction flip add remove
@@ -56,6 +57,7 @@
         empty-list-syntax
         cons-list-syntax
         list-syntax
+        string-syntax
         replace-loc
         syntax-case
         let-syntax


### PR DESCRIPTION
These changes allow strings to be used as syntax objects. Syntax containing strings can be constructed or matched against.

Also, in the process, quasiquote was updated to respect the source location of quotations, which means it should work for the purposes described in #83 .

I think this fixes #83, right @langston-barrett?