### PR TITLE
give every type an argument list

### DIFF
--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -382,12 +382,12 @@ initializeKernel = do
   where
     typePrims :: [(Text, (SplitTypePtr -> Syntax -> Expand (), TypePatternPtr -> Syntax -> Expand ()))]
     typePrims =
-      [ ("Syntax", Prims.baseType $ TyF TSyntax [])
-      , ("String", Prims.baseType $ TyF TString [])
-      , ("Signal", Prims.baseType $ TyF TSignal [])
+      [ ("Syntax", Prims.baseType tSyntax)
+      , ("String", Prims.baseType tString)
+      , ("Signal", Prims.baseType tSignal)
       , ("->", Prims.arrowType)
       , ("Macro", Prims.macroType)
-      , ("Type", Prims.baseType $ TyF TType [])
+      , ("Type", Prims.baseType tType)
       ]
 
     funPrims :: [(Text, Scheme Ty, Value)]
@@ -504,7 +504,7 @@ initializeKernel = do
                  then throwError $ WrongDatatypeArity stx dt arity (length args)
                  else do
                    argDests <- traverse scheduleType args
-                   linkType dest $ TyF (TDatatype dt) argDests
+                   linkType dest $ tDatatype dt argDests
           patImpl =
             \dest stx -> do
               Stx _ _ (me, args) <- mustBeCons stx
@@ -520,7 +520,7 @@ initializeKernel = do
                          | (sc, n, x) <- varInfo
                          ]
                   linkTypePattern dest $
-                    TypePattern $ TyF (TDatatype dt) [(varStx, var) | (_, varStx, var) <- varInfo]
+                    TypePattern $ tDatatype dt [(varStx, var) | (_, varStx, var) <- varInfo]
       let val = EPrimTypeMacro tyImpl patImpl
       b <- freshBinding
       bind b val
@@ -1053,7 +1053,7 @@ expandOneForm prob stx
             List xs -> expandOneExpression t dest (addApp List stx xs)
         ETypeVar i -> do
           dest <- requireTypeCtx stx prob
-          linkType dest $ TyF (TSchemaVar i) []
+          linkType dest $ tSchemaVar i
         EIncompleteDefn x n d -> do
           (t, dest) <- requireExpressionCtx stx prob
           forkAwaitingDefn x n b d t dest stx

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -393,7 +393,7 @@ initializeKernel = do
     funPrims :: [(Text, Scheme Ty, Value)]
     funPrims =
       [ ( "string=?"
-        , Scheme 0 (tString `tFun` tString `tFun` Prims.primitiveDatatype "Bool" [])
+        , Scheme 0 $ tFun [tString, tString] (Prims.primitiveDatatype "Bool" [])
         , ValueClosure $ HO $
           \(ValueString str1) ->
             ValueClosure $ HO $
@@ -403,7 +403,7 @@ initializeKernel = do
                 else primitiveCtor "false" []
         )
       , ( "string-append"
-        , Scheme 0 (tString `tFun` tString `tFun` tString)
+        , Scheme 0 $ tFun [tString, tString] tString
         , ValueClosure $ HO $
           \(ValueString str1) ->
             ValueClosure $ HO $

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -86,7 +86,7 @@ import qualified ScopeSet
 expandExpr :: Syntax -> Expand SplitCore
 expandExpr stx = do
   dest <- liftIO $ newSplitCorePtr
-  t <- Ty . TMetaVar <$> freshMeta
+  t <- tMetaVar <$> freshMeta
   forkExpandSyntax (ExprDest t dest) stx
   expandTasks
   children <- view expanderCompletedCore <$> getState
@@ -382,18 +382,18 @@ initializeKernel = do
   where
     typePrims :: [(Text, (SplitTypePtr -> Syntax -> Expand (), TypePatternPtr -> Syntax -> Expand ()))]
     typePrims =
-      [ ("Syntax", Prims.baseType TSyntax)
-      , ("String", Prims.baseType TString)
-      , ("Signal", Prims.baseType TSignal)
+      [ ("Syntax", Prims.baseType $ TyF TSyntax [])
+      , ("String", Prims.baseType $ TyF TString [])
+      , ("Signal", Prims.baseType $ TyF TSignal [])
       , ("->", Prims.arrowType)
       , ("Macro", Prims.macroType)
-      , ("Type", Prims.baseType TType)
+      , ("Type", Prims.baseType $ TyF TType [])
       ]
 
     funPrims :: [(Text, Scheme Ty, Value)]
     funPrims =
       [ ( "string=?"
-        , Scheme 0 $ Ty (TFun (Ty TString) (Ty (TFun (Ty TString) (Prims.primitiveDatatype "Bool" []))))
+        , Scheme 0 (tString `tFun` tString `tFun` Prims.primitiveDatatype "Bool" [])
         , ValueClosure $ HO $
           \(ValueString str1) ->
             ValueClosure $ HO $
@@ -403,7 +403,7 @@ initializeKernel = do
                 else primitiveCtor "false" []
         )
       , ( "string-append"
-        , Scheme 0 $ Ty (TFun (Ty TString) (Ty (TFun (Ty TString) (Ty TString))))
+        , Scheme 0 (tString `tFun` tString `tFun` tString)
         , ValueClosure $ HO $
           \(ValueString str1) ->
             ValueClosure $ HO $
@@ -417,8 +417,8 @@ initializeKernel = do
       [ ("ScopeAction", 0, [("flip", []), ("add", []), ("remove", [])])
       , ("Unit", 0, [("unit", [])])
       , ("Bool", 0, [("true", []), ("false", [])])
-      , ("Problem", 0, [("declaration", []), ("expression", [Ty TType]), ("type", []), ("pattern", [])])
-      , ("Maybe", 1, [("nothing", []), ("just", [Ty $ TSchemaVar 0])])
+      , ("Problem", 0, [("declaration", []), ("expression", [tType]), ("type", []), ("pattern", [])])
+      , ("Maybe", 1, [("nothing", []), ("just", [tSchemaVar 0])])
       ]
 
     modPrims :: [(Text, Syntax -> Expand ())]
@@ -504,7 +504,7 @@ initializeKernel = do
                  then throwError $ WrongDatatypeArity stx dt arity (length args)
                  else do
                    argDests <- traverse scheduleType args
-                   linkType dest $ TDatatype dt argDests
+                   linkType dest $ TyF (TDatatype dt) argDests
           patImpl =
             \dest stx -> do
               Stx _ _ (me, args) <- mustBeCons stx
@@ -513,14 +513,14 @@ initializeKernel = do
                 then throwError $ WrongDatatypeArity stx dt arity (length args)
                 else do
                   varInfo <- traverse Prims.prepareVar args
-                  sch <- trivialScheme $ Ty TType
+                  sch <- trivialScheme tType
                   modifyState $
                     set (expanderPatternBinders . at (Right dest)) $
                     Just [ (sc, n, x, sch)
                          | (sc, n, x) <- varInfo
                          ]
                   linkTypePattern dest $
-                    TypePattern $ TDatatype dt [(varStx, var) | (_, varStx, var) <- varInfo]
+                    TypePattern $ TyF (TDatatype dt) [(varStx, var) | (_, varStx, var) <- varInfo]
       let val = EPrimTypeMacro tyImpl patImpl
       b <- freshBinding
       bind b val
@@ -745,11 +745,13 @@ runTask (tid, localData, task) = withLocal localData $ do
     AwaitingTypeCase loc dest ty env cases kont -> do
       Ty t <- normType ty
       case t of
-        TMetaVar ptr' ->
+        TyF (TMetaVar ptr') [] -> do
           -- Always wait on the canonical representative
           case ty of
-            Ty (TMetaVar ptr) | ptr == ptr' -> stillStuck tid task
-            _ -> forkAwaitingTypeCase loc dest (Ty (TMetaVar ptr')) env cases kont
+            Ty (TyF (TMetaVar ptr) []) | ptr == ptr' -> stillStuck tid task
+            _ -> forkAwaitingTypeCase loc dest (tMetaVar ptr') env cases kont
+        TyF (TMetaVar _) _ -> do
+          throwError $ InternalError "type variable cannot have parameters (yet)"
         other -> do
           selectedBranch <- expandEval $ withEnv env $ doTypeCase loc (Ty other) cases
           case selectedBranch of
@@ -990,7 +992,7 @@ expandOneForm prob stx
           case prob of
             ExprDest t dest -> do
               argTys <- makeTypeMetas arity
-              unify dest t (Ty (TDatatype dt argTys))
+              unify dest t $ tDatatype dt argTys
               args' <- for args \a -> inst (Scheme arity a) argTys
               Stx _ _ (foundName, foundArgs) <- mustBeCons stx
               _ <- mustBeIdent foundName
@@ -1007,7 +1009,7 @@ expandOneForm prob stx
               argTypes <- for args \ a -> do
                             t <- inst (Scheme arity a) tyArgs
                             trivialScheme t
-              unify loc (Ty (TDatatype dt tyArgs)) patTy
+              unify loc (tDatatype dt tyArgs) patTy
               if length patVars /= length argTypes
                 then throwError $ WrongArgCount stx ctor (length argTypes) (length patVars)
                 else do
@@ -1051,7 +1053,7 @@ expandOneForm prob stx
             List xs -> expandOneExpression t dest (addApp List stx xs)
         ETypeVar i -> do
           dest <- requireTypeCtx stx prob
-          linkType dest (TSchemaVar i)
+          linkType dest $ TyF (TSchemaVar i) []
         EIncompleteDefn x n d -> do
           (t, dest) <- requireExpressionCtx stx prob
           forkAwaitingDefn x n b d t dest stx
@@ -1100,11 +1102,11 @@ expandOneForm prob stx
         case syntaxE stx of
           List xs -> expandOneExpression t dest (addApp List stx xs)
           Sig s -> do
-            unify dest (Ty TSignal) t
+            unify dest tSignal t
             expandLiteralSignal dest s
             saveExprType dest t
           String s -> do
-            unify dest (Ty TString) t
+            unify dest tString t
             expandLiteralString dest s
             saveExprType dest t
           Id _ -> error "Impossible happened - identifiers are identifier-headed!"

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -110,7 +110,7 @@ define dest outScopesDest stx = do
   schPtr <- liftIO $ newSchemePtr
   linkOneDecl dest (Define x var schPtr exprDest)
   t <- inTypeBinder do
-    t <- Ty . TMetaVar <$> freshMeta
+    t <- tMetaVar <$> freshMeta
     forkExpandSyntax (ExprDest t exprDest) expr
     return t
   ph <- currentPhase
@@ -172,7 +172,7 @@ defineMacros dest outScopesDest stx = do
     b <- freshBinding
     addDefinedBinding theName b
     macroDest <- inEarlierPhase $
-                   schedule (Ty (TFun (Ty TSyntax) (Ty (TMacro (Ty TSyntax)))))
+                   schedule (tSyntax `tFun` tMacro tSyntax)
                      (addScope p mdef sc)
     v <- freshMacroVar
     bind b $ EIncompleteMacro v theName macroDest
@@ -187,7 +187,7 @@ example dest outScopesDest stx = do
   sch <- liftIO newSchemePtr
   linkOneDecl dest (Example (view (unSyntax . stxSrcLoc) stx) sch exprDest)
   t <- inTypeBinder do
-    t <- Ty . TMetaVar <$> freshMeta
+    t <- tMetaVar <$> freshMeta
     forkExpandSyntax (ExprDest t exprDest) expr
     return t
   forkGeneralizeType exprDest t sch
@@ -215,7 +215,7 @@ oops _t _dest stx = throwError (InternalError $ "oops" ++ show stx)
 err :: ExprPrim
 err _t dest stx = do
   Stx _ _ (_ :: Syntax, msg) <- mustHaveEntries stx
-  msgDest <- schedule (Ty TSyntax) msg
+  msgDest <- schedule tSyntax msg
   linkExpr dest $ CoreError msgDest
 
 the :: ExprPrim
@@ -233,7 +233,7 @@ letExpr t dest stx = do
   p <- currentPhase
   psc <- phaseRoot
   (defDest, xTy) <- inTypeBinder do
-    xt <- Ty . TMetaVar <$> freshMeta
+    xt <- tMetaVar <$> freshMeta
     defDest <- schedule xt def
     return (defDest, xt)
   sch <- liftIO $ newSchemePtr
@@ -244,9 +244,9 @@ letExpr t dest stx = do
 
 flet :: ExprPrim
 flet t dest stx = do
-  ft <- inTypeBinder $ Ty . TMetaVar <$> freshMeta
-  xt <- inTypeBinder $ Ty . TMetaVar <$> freshMeta
-  rt <- inTypeBinder $ Ty . TMetaVar <$> freshMeta
+  ft <- inTypeBinder $ tMetaVar <$> freshMeta
+  xt <- inTypeBinder $ tMetaVar <$> freshMeta
+  rt <- inTypeBinder $ tMetaVar <$> freshMeta
   fsch <- trivialScheme ft
   xsch <- trivialScheme xt
   Stx _ _ (_, b, body) <- mustHaveEntries stx
@@ -261,7 +261,7 @@ flet t dest stx = do
              withLocalVarType x' coreX xsch $
              schedule rt $
              addScope p (addScope p (addScope p def fsc) xsc) psc
-  unify dest ft (Ty (TFun xt rt))
+  unify dest ft (xt `tFun` rt)
   sch <- liftIO newSchemePtr
   forkGeneralizeType defDest ft sch
   bodyDest <- withLocalVarType f' coreF sch $
@@ -276,9 +276,9 @@ lambda t dest stx = do
   (sc, arg', coreArg) <- prepareVar theArg
   p <- currentPhase
   psc <- phaseRoot
-  argT <- Ty . TMetaVar <$> freshMeta
-  retT <- Ty . TMetaVar <$> freshMeta
-  unify dest t (Ty (TFun argT retT))
+  argT <- tMetaVar <$> freshMeta
+  retT <- tMetaVar <$> freshMeta
+  unify dest t (argT `tFun` retT)
   sch <- trivialScheme argT
   bodyDest <-
     withLocalVarType arg' coreArg sch $
@@ -287,129 +287,129 @@ lambda t dest stx = do
 
 app :: ExprPrim
 app t dest stx = do
-  argT <- Ty . TMetaVar <$> freshMeta
+  argT <- tMetaVar <$> freshMeta
   Stx _ _ (_, fun, arg) <- mustHaveEntries stx
-  funDest <- schedule (Ty (TFun argT t)) fun
+  funDest <- schedule (argT `tFun` t) fun
   argDest <- schedule argT arg
   linkExpr dest $ CoreApp funDest argDest
 
 pureMacro :: ExprPrim
 pureMacro t dest stx = do
   Stx _ _ (_ :: Syntax, v) <- mustHaveEntries stx
-  innerT <- Ty . TMetaVar <$> freshMeta
-  unify dest (Ty (TMacro innerT)) t
+  innerT <- tMetaVar <$> freshMeta
+  unify dest (tMacro innerT) t
   argDest <- schedule innerT v
   linkExpr dest $ CorePure argDest
 
 
 bindMacro :: ExprPrim
 bindMacro t dest stx = do
-  a <- Ty . TMetaVar <$> freshMeta
-  b <- Ty . TMetaVar <$> freshMeta
+  a <- tMetaVar <$> freshMeta
+  b <- tMetaVar <$> freshMeta
   Stx _ _ (_, act, cont) <- mustHaveEntries stx
-  actDest <- schedule (Ty (TMacro a)) act
-  contDest <- schedule (Ty (TFun a (Ty (TMacro b)))) cont
-  unify dest t (Ty (TMacro b))
+  actDest <- schedule (tMacro a) act
+  contDest <- schedule (a `tFun` tMacro b) cont
+  unify dest t (tMacro b)
   linkExpr dest $ CoreBind actDest contDest
 
 syntaxError :: ExprPrim
 syntaxError t dest stx = do
-  a <- Ty . TMetaVar <$> freshMeta
-  unify dest t (Ty (TMacro a))
+  a <- tMetaVar <$> freshMeta
+  unify dest t (tMacro a)
   Stx scs srcloc (_, args) <- mustBeCons stx
   Stx _ _ (msg, locs) <- mustBeCons $ Syntax $ Stx scs srcloc (List args)
-  msgDest <- schedule (Ty TSyntax) msg
-  locDests <- traverse (schedule (Ty TSyntax)) locs
+  msgDest <- schedule tSyntax msg
+  locDests <- traverse (schedule tSyntax) locs
   linkExpr dest $ CoreSyntaxError (SyntaxError locDests msgDest)
 
 sendSignal :: ExprPrim
 sendSignal t dest stx = do
-  unify dest t (Ty (TMacro (primitiveDatatype "Unit" [])))
+  unify dest t (tMacro (primitiveDatatype "Unit" []))
   Stx _ _ (_ :: Syntax, sig) <- mustHaveEntries stx
-  sigDest <- schedule (Ty TSignal) sig
+  sigDest <- schedule tSignal sig
   linkExpr dest $ CoreSendSignal sigDest
 
 waitSignal :: ExprPrim
 waitSignal t dest stx = do
-  unify dest t (Ty (TMacro (primitiveDatatype "Unit" [])))
+  unify dest t (tMacro (primitiveDatatype "Unit" []))
   Stx _ _ (_ :: Syntax, sig) <- mustHaveEntries stx
-  sigDest <- schedule (Ty TSignal) sig
+  sigDest <- schedule tSignal sig
   linkExpr dest $ CoreWaitSignal sigDest
 
 identEqual :: HowEq -> ExprPrim
 identEqual how t dest stx = do
-  unify dest t (Ty (TMacro (primitiveDatatype "Bool" [])))
+  unify dest t (tMacro (primitiveDatatype "Bool" []))
   Stx _ _ (_ :: Syntax, id1, id2) <- mustHaveEntries stx
-  newE <- CoreIdentEq how <$> schedule (Ty TSyntax) id1 <*> schedule (Ty TSyntax) id2
+  newE <- CoreIdentEq how <$> schedule tSyntax id1 <*> schedule tSyntax id2
   linkExpr dest newE
 
 quote :: ExprPrim
 quote t dest stx = do
-  unify dest (Ty TSyntax) t
+  unify dest tSyntax t
   Stx _ _ (_ :: Syntax, quoted) <- mustHaveEntries stx
   linkExpr dest $ CoreSyntax quoted
 
 ident :: ExprPrim
 ident t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, someId) <- mustHaveEntries stx
   x@(Stx _ _ _) <- mustBeIdent someId
   linkExpr dest $ CoreIdentifier x
 
 identSyntax :: ExprPrim
 identSyntax t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, someId, source) <- mustHaveEntries stx
-  idDest <- schedule (Ty TSyntax) someId
-  sourceDest <- schedule (Ty TSyntax) source
+  idDest <- schedule tSyntax someId
+  sourceDest <- schedule tSyntax source
   linkExpr dest $ CoreIdent $ ScopedIdent idDest sourceDest
 
 emptyListSyntax :: ExprPrim
 emptyListSyntax t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, source) <- mustHaveEntries stx
-  sourceDest <- schedule (Ty TSyntax) source
+  sourceDest <- schedule tSyntax source
   linkExpr dest $ CoreEmpty $ ScopedEmpty sourceDest
 
 consListSyntax :: ExprPrim
 consListSyntax t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, car, cdr, source) <- mustHaveEntries stx
-  carDest <- schedule (Ty TSyntax) car
-  cdrDest <- schedule (Ty TSyntax) cdr
-  sourceDest <- schedule (Ty TSyntax) source
+  carDest <- schedule tSyntax car
+  cdrDest <- schedule tSyntax cdr
+  sourceDest <- schedule tSyntax source
   linkExpr dest $ CoreCons $ ScopedCons carDest cdrDest sourceDest
 
 listSyntax :: ExprPrim
 listSyntax t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, list, source) <- mustHaveEntries stx
   Stx _ _ listItems <- mustHaveEntries list
-  listDests <- traverse (schedule (Ty TSyntax)) listItems
-  sourceDest <- schedule (Ty TSyntax) source
+  listDests <- traverse (schedule tSyntax) listItems
+  sourceDest <- schedule tSyntax source
   linkExpr dest $ CoreList $ ScopedList listDests sourceDest
 
 stringSyntax :: ExprPrim
 stringSyntax t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, str, source) <- mustHaveEntries stx
-  strDest <- schedule (Ty TString) str
-  sourceDest <- schedule (Ty TSyntax) source
+  strDest <- schedule tString str
+  sourceDest <- schedule tSyntax source
   linkExpr dest $ CoreStringSyntax $ ScopedString strDest sourceDest
 
 replaceLoc :: ExprPrim
 replaceLoc t dest stx = do
-  unify dest t (Ty (TSyntax))
+  unify dest t tSyntax
   Stx _ _ (_ :: Syntax, loc, valStx) <- mustHaveEntries stx
-  locDest <- schedule (Ty TSyntax) loc
-  valStxDest <- schedule (Ty TSyntax) valStx
+  locDest <- schedule tSyntax loc
+  valStxDest <- schedule tSyntax valStx
   linkExpr dest $ CoreReplaceLoc locDest valStxDest
 
 syntaxCase :: ExprPrim
 syntaxCase t dest stx = do
   Stx scs loc (_ :: Syntax, args) <- mustBeCons stx
   Stx _ _ (scrutinee, patterns) <- mustBeCons (Syntax (Stx scs loc (List args)))
-  scrutDest <- schedule (Ty TSyntax) scrutinee
+  scrutDest <- schedule tSyntax scrutinee
   patternDests <- traverse (mustHaveEntries >=> expandPatternCase t) patterns
   linkExpr dest $ CoreCase loc scrutDest patternDests
 
@@ -431,7 +431,7 @@ letSyntax t dest stx = do
   v <- freshMacroVar
   macroDest <- inEarlierPhase $ do
     psc <- phaseRoot
-    schedule (Ty (TFun (Ty TSyntax) (Ty (TMacro (Ty TSyntax)))))
+    schedule (tSyntax `tFun` tMacro tSyntax)
       (addScope (prior p) mdef psc)
   forkAwaitingMacro b v m' macroDest (ExprDest t dest) (addScope p body sc)
 
@@ -444,26 +444,25 @@ makeIntroducer t dest stx = do
 
   where
     theType =
-      Ty $ TMacro $ Ty $ TFun (primitiveDatatype "ScopeAction" []) $
-      Ty $ TFun (Ty TSyntax) (Ty TSyntax)
+      tMacro (primitiveDatatype "ScopeAction" [] `tFun` tSyntax `tFun` tSyntax)
 
 log :: ExprPrim
 log t dest stx = do
-  unify dest (Ty (TMacro (primitiveDatatype "Unit" []))) t
+  unify dest (tMacro (primitiveDatatype "Unit" [])) t
   Stx _ _ (_ :: Syntax, message) <- mustHaveEntries stx
-  msgDest <- schedule (Ty TSyntax) message
+  msgDest <- schedule tSyntax message
   linkExpr dest $ CoreLog msgDest
 
 whichProblem :: ExprPrim
 whichProblem t dest stx = do
-  unify dest (Ty (TMacro (primitiveDatatype "Problem" []))) t
+  unify dest (tMacro (primitiveDatatype "Problem" [])) t
   Stx _ _ (_ :: Syntax) <- mustHaveEntries stx
   linkExpr dest CoreWhichProblem
 
 dataCase :: ExprPrim
 dataCase t dest stx = do
   Stx _ loc (_, scrut, cases) <- mustBeConsCons stx
-  a <- Ty . TMetaVar <$> freshMeta
+  a <- tMetaVar <$> freshMeta
   scrutineeDest <- schedule a scrut
   cases' <- traverse (mustHaveEntries >=> scheduleDataPattern t a) cases
   linkExpr dest $ CoreDataCase loc scrutineeDest cases'
@@ -471,9 +470,9 @@ dataCase t dest stx = do
 typeCase :: ExprPrim
 typeCase t dest stx = do
   Stx _ loc (_, scrut, cases) <- mustBeConsCons stx
-  a <- Ty . TMetaVar <$> freshMeta
-  unify dest (Ty (TMacro a)) t
-  scrutineeDest <- schedule (Ty TType) scrut
+  a <- tMetaVar <$> freshMeta
+  unify dest (tMacro a) t
+  scrutineeDest <- schedule tType scrut
   cases' <- traverse (mustHaveEntries >=> scheduleTypePattern t) cases
   linkExpr dest $ CoreTypeCase loc scrutineeDest cases'
 
@@ -500,19 +499,19 @@ arrowType = (implT, implP)
       Stx _ _ (_ :: Syntax, arg, ret) <- mustHaveEntries stx
       argDest <- scheduleType arg
       retDest <- scheduleType ret
-      linkType dest (TFun argDest retDest)
+      linkType dest $ TyF TFun [argDest, retDest]
     implP dest stx = do
       Stx _ _ (_ :: Syntax, arg, ret) <- mustHaveEntries stx
       (sc1, n1, x1) <- prepareVar arg
       (sc2, n2, x2) <- prepareVar ret
-      sch <- trivialScheme $ Ty $ TType
+      sch <- trivialScheme tType
       modifyState $
         set (expanderPatternBinders . at (Right dest)) $
         Just [(sc1, n1, x1, sch), (sc2, n2, x2, sch)]
-      linkTypePattern dest $ TypePattern $ TFun (n1, x1) (n2, x2)
+      linkTypePattern dest $ TypePattern $ TyF TFun [(n1, x1), (n2, x2)]
 
 macroType :: TypePrim
-macroType = unaryType TMacro
+macroType = unaryType (\a -> TyF TMacro [a])
 
 unaryType :: (forall a . a -> TyF a) -> TypePrim
 unaryType ctor = (implT, implP)
@@ -524,7 +523,7 @@ unaryType ctor = (implT, implP)
     implP dest stx = do
       Stx _ _ (_ :: Syntax, a) <- mustHaveEntries stx
       (sc, n, x) <- prepareVar a
-      sch <- trivialScheme $ Ty $ TType
+      sch <- trivialScheme tType
       modifyState $
         set (expanderPatternBinders . at (Right dest)) $
         Just [(sc, n, x, sch)]
@@ -564,7 +563,7 @@ makeLocalType dest stx = do
 
   let tyImpl tdest tstx = do
         _ <- mustBeIdent tstx
-        linkType tdest t
+        linkType tdest $ TyF t []
   let patImpl _ tstx =
         throwError $ NotValidType tstx
 
@@ -590,7 +589,7 @@ elsePattern (Left (_exprTy, scrutTy, dest)) stx = do
   linkPattern dest $ AnyConstructor x v
 elsePattern (Right (_exprTy, dest)) stx = do
   Stx _ _ (_ :: Syntax, var) <- mustHaveEntries stx
-  ty <- trivialScheme (Ty TType)
+  ty <- trivialScheme tType
   (sc, x, v) <- prepareVar var
   modifyState $ set (expanderPatternBinders . at (Right dest)) $
     Just [(sc, x, v, ty)]
@@ -611,7 +610,7 @@ addDatatype name dt arity = do
             then throwError $ WrongDatatypeArity stx dt arity (length args)
             else do
               argDests <- traverse scheduleType args
-              linkType dest $ TDatatype dt argDests
+              linkType dest $ TyF (TDatatype dt) argDests
       implPat =
         \dest stx -> do
           Stx _ _ (me, args) <- mustBeCons stx
@@ -620,13 +619,13 @@ addDatatype name dt arity = do
             then throwError $ WrongDatatypeArity stx dt arity (length args)
             else do
               patVarInfo <- traverse prepareVar args
-              sch <- trivialScheme $ Ty $ TType
+              sch <- trivialScheme tType
               modifyState $
                 set (expanderPatternBinders . at (Right dest)) $
                 Just [ (sc, n, x, sch)
                      | (sc, n, x) <- patVarInfo
                      ]
-              linkTypePattern dest $ TypePattern $ TDatatype dt [(n, x) | (_, n, x) <- patVarInfo]
+              linkTypePattern dest $ TypePattern $ TyF (TDatatype dt) [(n, x) | (_, n, x) <- patVarInfo]
   let val = EPrimTypeMacro implType implPat
   b <- freshBinding
   addDefinedBinding name' b
@@ -637,7 +636,7 @@ expandPatternCase :: Ty -> Stx (Syntax, Syntax) -> Expand (SyntaxPattern, SplitC
 -- TODO match case keywords hygienically
 expandPatternCase t (Stx _ _ (lhs, rhs)) = do
   p <- currentPhase
-  sch <- trivialScheme (Ty TSyntax)
+  sch <- trivialScheme tSyntax
   case lhs of
     Syntax (Stx _ _ (List [Syntax (Stx _ _ (Id "ident")),
                            patVar])) -> do
@@ -650,7 +649,7 @@ expandPatternCase t (Stx _ _ (lhs, rhs)) = do
                            patVar])) -> do
       (sc, x', var) <- prepareVar patVar
       let rhs' = addScope p rhs sc
-      strSch <- trivialScheme (Ty TString)
+      strSch <- trivialScheme tString
       rhsDest <- withLocalVarType x' var strSch $ schedule t rhs'
       let patOut = SyntaxPatternString x' var
       return (patOut, rhsDest)
@@ -734,5 +733,5 @@ primitiveDatatype name args =
   let dt = Datatype { _datatypeModule = KernelName kernelName
                     , _datatypeName = DatatypeName name
                     }
-  in Ty $ TDatatype dt args
+  in tDatatype dt args
 

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -499,7 +499,7 @@ arrowType = (implT, implP)
       Stx _ _ (_ :: Syntax, arg, ret) <- mustHaveEntries stx
       argDest <- scheduleType arg
       retDest <- scheduleType ret
-      linkType dest $ TyF TFun [argDest, retDest]
+      linkType dest (argDest `tFun` retDest)
     implP dest stx = do
       Stx _ _ (_ :: Syntax, arg, ret) <- mustHaveEntries stx
       (sc1, n1, x1) <- prepareVar arg
@@ -508,10 +508,10 @@ arrowType = (implT, implP)
       modifyState $
         set (expanderPatternBinders . at (Right dest)) $
         Just [(sc1, n1, x1, sch), (sc2, n2, x2, sch)]
-      linkTypePattern dest $ TypePattern $ TyF TFun [(n1, x1), (n2, x2)]
+      linkTypePattern dest $ TypePattern ((n1, x1) `tFun` (n2, x2))
 
 macroType :: TypePrim
-macroType = unaryType (\a -> TyF TMacro [a])
+macroType = unaryType (\a -> tMacro a)
 
 unaryType :: (forall a . a -> TyF a) -> TypePrim
 unaryType ctor = (implT, implP)
@@ -610,7 +610,7 @@ addDatatype name dt arity = do
             then throwError $ WrongDatatypeArity stx dt arity (length args)
             else do
               argDests <- traverse scheduleType args
-              linkType dest $ TyF (TDatatype dt) argDests
+              linkType dest $ tDatatype dt argDests
       implPat =
         \dest stx -> do
           Stx _ _ (me, args) <- mustBeCons stx
@@ -625,7 +625,7 @@ addDatatype name dt arity = do
                 Just [ (sc, n, x, sch)
                      | (sc, n, x) <- patVarInfo
                      ]
-              linkTypePattern dest $ TypePattern $ TyF (TDatatype dt) [(n, x) | (_, n, x) <- patVarInfo]
+              linkTypePattern dest $ TypePattern $ tDatatype dt [(n, x) | (_, n, x) <- patVarInfo]
   let val = EPrimTypeMacro implType implPat
   b <- freshBinding
   addDefinedBinding name' b

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -185,9 +185,7 @@ generalizeType ty = do
 
 
 makeTypeMetas :: Natural -> Expand [Ty]
-makeTypeMetas n = replicateM (fromIntegral n) $ do
-  meta <- freshMeta
-  pure $ Ty $ TyF (TMetaVar meta) []
+makeTypeMetas n = replicateM (fromIntegral n) $ tMetaVar <$> freshMeta
 
 class UnificationErrorBlame a where
   getBlameLoc :: a -> Expand (Maybe SrcLoc)

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -120,9 +120,7 @@ inst (Scheme n ty) ts
 
 specialize :: Scheme Ty -> Expand Ty
 specialize sch@(Scheme n _) = do
-  freshVars <- replicateM (fromIntegral n) $ do
-    meta <- freshMeta
-    pure $ Ty $ TyF (TMetaVar meta) []
+  freshVars <- makeTypeMetas n
   inst sch freshVars
 
 varType :: Var -> Expand (Maybe (Scheme Ty))

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -111,6 +111,10 @@ inst (Scheme n ty) ts
     instTyF (TyF ctor tArgs) = do
       let TyF ctor' tArgsPrefix = instCtor ctor
       tArgsSuffix <- traverse instTy tArgs
+
+      -- If ctor was a TSchemaVar which got instantiated to a partially applied
+      -- type constructor such as (TyF TFun [TSignal]), we want to append the remaining
+      -- type arguments, e.g. [TSyntax], in order to get (TyF TFun [TSignal, TSyntax]).
       pure $ TyF ctor' (tArgsPrefix ++ tArgsSuffix)
 
     instCtor :: TypeConstructor -> TyF Ty

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -319,20 +319,24 @@ typeVarNames =
                ]
 
 
+instance Pretty VarInfo TypeConstructor where
+  pp _   TSyntax        = text "Syntax"
+  pp _   TSignal        = text "Signal"
+  pp _   TString        = text "String"
+  pp _   TFun           = text "(→)"
+  pp _   TMacro         = text "Macro"
+  pp _   TType          = text "Type"
+  pp env (TDatatype t)  = pp env t
+  pp _   (TSchemaVar n) = text $ typeVarNames !! fromIntegral n
+  pp _   (TMetaVar v)   = text "META" <> viaShow v -- TODO
+
 instance Pretty VarInfo a => Pretty VarInfo (TyF a) where
-  pp _ TSyntax = text "Syntax"
-  pp _ TSignal = text "Signal"
-  pp _ TString = text "String"
-  pp env (TFun a b) =
+  pp env (TyF TFun [a, b]) =
     parens $ align $ group $ vsep [pp env a <+> text "→", pp env b]
-  pp env (TMacro a) = parens (text "Macro" <+> align (pp env a))
-  pp _env TType = text "Type"
-  pp env (TDatatype t args) =
+  pp env (TyF ctor args) =
     case args of
-      [] -> pp env t
-      more -> parens (align $ group $ pp env t <+> vsep (map (pp env) more))
-  pp _ (TSchemaVar n) = text $ typeVarNames !! fromIntegral n
-  pp _ (TMetaVar v) = text "META" <> viaShow v -- TODO
+      [] -> pp env ctor
+      more -> parens (align $ group $ pp env ctor <+> vsep (map (pp env) more))
 
 instance Pretty VarInfo Datatype where
   pp _ d = text (view (datatypeName . datatypeNameText) d)

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -97,19 +97,18 @@ class TyLike a arg | a -> arg where
   tSyntax    :: a
   tSignal    :: a
   tString    :: a
-  tFun       :: arg -> arg -> a
+  tFun1      :: arg -> arg -> a
   tMacro     :: arg -> a
   tType      :: a
   tDatatype  :: Datatype -> [arg] -> a
   tSchemaVar :: Natural -> a
   tMetaVar   :: MetaPtr -> a
-infixr 9 `tFun`
 
 instance TyLike (TyF a) a where
   tSyntax        = TyF TSyntax []
   tSignal        = TyF TSignal []
   tString        = TyF TString []
-  tFun t1 t2     = TyF TFun [t1, t2]
+  tFun1 t1 t2    = TyF TFun [t1, t2]
   tMacro t       = TyF TMacro [t]
   tType          = TyF TType []
   tDatatype x ts = TyF (TDatatype x) ts
@@ -120,9 +119,12 @@ instance TyLike Ty Ty where
   tSyntax        = Ty $ tSyntax
   tSignal        = Ty $ tSignal
   tString        = Ty $ tString
-  tFun t1 t2     = Ty $ tFun t1 t2
+  tFun1 t1 t2    = Ty $ tFun1 t1 t2
   tMacro t       = Ty $ tMacro t
   tType          = Ty $ tType
   tDatatype x ts = Ty $ tDatatype x ts
   tSchemaVar x   = Ty $ tSchemaVar x
   tMetaVar x     = Ty $ tMetaVar x
+
+tFun :: [Ty] -> Ty -> Ty
+tFun args result = foldr tFun1 result args


### PR DESCRIPTION
possibly an empty one. in practice, the type constructor determines the
length of that list, so TFun always has 2 arguments and TString always
has zero. thus, this more-uniform representation is less precise than
before, in that it makes more illegal states representable, but it paves
the way for the implementation of higher-kinded types. for example, it
is now possible to represent TFun applied to zero or one argument;
currently, writing either of those in a Klister program is a kind error,
but soon we can make those types of kind `* -> * -> *` and `* -> *`.