### PR TITLE
Add deep pattern matching to core language

### DIFF
--- a/examples/deep-patterns.golden
+++ b/examples/deep-patterns.golden
@@ -1,0 +1,8 @@
+(add1 (add1 (zero))) : Nat
+(add1 (add1 (zero))) : Nat
+(add1 (add1 (zero))) : Nat
+(add1 (add1 (zero))) : Nat
+(true) : Bool
+(false) : Bool
+(false) : Bool
+(pair 0 (pair (zero) "zero")) : (Pair Integer (Pair Nat String))

--- a/examples/deep-patterns.kl
+++ b/examples/deep-patterns.kl
@@ -1,0 +1,49 @@
+#lang kernel
+
+(datatype (Nat)
+  (zero)
+  (add1 (Nat)))
+
+(define half
+  (flet (half (n)
+          (case n
+            ((zero) (zero))
+            ((add1 (zero)) (zero))
+            ((add1 (add1 k)) (add1 (half k)))))
+    half))
+
+(example (half (add1 (add1 (add1 (add1 (zero)))))))
+(example (half (add1 (add1 (add1 (add1 (add1 (zero))))))))
+
+(define half*
+  (flet (half* (n)
+          (case n
+            ((add1 (add1 k)) (add1 (half* k)))
+            (_ (zero))))
+    half*))
+
+(example (half* (add1 (add1 (add1 (add1 (zero)))))))
+(example (half* (add1 (add1 (add1 (add1 (add1 (zero))))))))
+
+
+(define four?
+  (lambda (x)
+    (case x
+      ((add1 (add1 (add1 (add1 (zero))))) (true))
+      (_ (false)))))
+
+(example (four? (add1 (add1 (add1 (add1 (zero)))))))
+(example (four? (add1 (add1 (add1 (zero))))))
+(example (four? (add1 (add1 (add1 (add1 (add1 (zero))))))))
+
+
+(datatype (Pair A B)
+  (pair A B))
+
+(define reassoc
+  (lambda (x)
+    (case x
+      ((pair (pair x y) z) (pair x (pair y z))))))
+
+(example (reassoc (pair (pair 0 (zero)) "zero")))
+

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -70,15 +70,15 @@ data ConstructorPatternF pat
 makePrisms ''ConstructorPatternF
 
 newtype ConstructorPattern =
-  ConstructorPattern { _constructorPattern :: ConstructorPatternF ConstructorPattern }
+  ConstructorPattern { unConstructorPattern :: ConstructorPatternF ConstructorPattern }
   deriving (Data, Eq, Show)
-makeLenses ''ConstructorPattern
+makePrisms ''ConstructorPattern
 
 instance Phased a => Phased (ConstructorPatternF a) where
   shift i = fmap (shift i)
 
 instance Phased ConstructorPattern where
-  shift i = over constructorPattern (shift i)
+  shift i = over _ConstructorPattern (shift i)
 
 instance Phased TypePattern where
   shift _ = id
@@ -370,7 +370,7 @@ instance (AlphaEq typePat, AlphaEq pat, AlphaEq core) => AlphaEq (CoreF typePat 
 
 instance AlphaEq ConstructorPattern where
   alphaCheck p1 p2 =
-    alphaCheck (view constructorPattern p1) (view constructorPattern p2)
+    alphaCheck (unConstructorPattern p1) (unConstructorPattern p2)
 
 instance AlphaEq a => AlphaEq (ConstructorPatternF a) where
   alphaCheck (CtorPattern c1 vars1)
@@ -578,7 +578,7 @@ instance ShortShow Core where
   shortShow (Core x) = shortShow x
 
 instance ShortShow ConstructorPattern where
-  shortShow = shortShow . view constructorPattern
+  shortShow = shortShow . unConstructorPattern
 
 instance ShortShow a => ShortShow (ConstructorPatternF a) where
   shortShow (CtorPattern ctor vars) =

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -279,7 +279,7 @@ withScopeOf scope expr = do
 doDataCase :: SrcLoc -> Value -> [(ConstructorPattern, Core)] -> Eval Value
 doDataCase loc v0 [] = throwError (EvalErrorCase loc v0)
 doDataCase loc v0 ((pat, rhs) : ps) =
-  match (doDataCase loc v0 ps) (eval rhs) [(view constructorPattern pat, v0)]
+  match (doDataCase loc v0 ps) (eval rhs) [(unConstructorPattern pat, v0)]
   where
     match _fk sk [] = sk
     match fk sk ((CtorPattern ctor subPats, tgt) : more) =
@@ -288,7 +288,7 @@ doDataCase loc v0 ((pat, rhs) : ps) =
           | c == ctor ->
             if length subPats /= length args
               then error $ "Type checker bug: wrong number of pattern vars for constructor " ++ show c
-              else match fk sk (zip (map (view constructorPattern) subPats) args ++ more)
+              else match fk sk (zip (map unConstructorPattern subPats) args ++ more)
           | otherwise -> fk
         _otherValue -> fk
     match fk sk ((PatternVar n x, tgt) : more) =

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -278,22 +278,21 @@ withScopeOf scope expr = do
 
 doDataCase :: SrcLoc -> Value -> [(ConstructorPattern, Core)] -> Eval Value
 doDataCase loc v0 [] = throwError (EvalErrorCase loc v0)
-doDataCase loc v0 ((pat, rhs) : ps) = match (doDataCase loc v0 ps) pat
+doDataCase loc v0 ((pat, rhs) : ps) =
+  match (doDataCase loc v0 ps) (eval rhs) [(view constructorPattern pat, v0)]
   where
-    match next (ConstructorPattern ctor vars) =
-      case v0 of
+    match _fk sk [] = sk
+    match fk sk ((CtorPattern ctor subPats, tgt) : more) =
+      case tgt of
         ValueCtor c args
           | c == ctor ->
-            if length vars /= length args
+            if length subPats /= length args
               then error $ "Type checker bug: wrong number of pattern vars for constructor " ++ show c
-              else withManyExtendedEnv [ (n, x, v) | (n, x) <- vars
-                                       | v <- args
-                                       ] $
-                   eval rhs
-          | otherwise -> next
-        _otherValue -> next
-    match _next (AnyConstructor n x) =
-      withExtendedEnv n x v0 $ eval rhs
+              else match fk sk (zip (map (view constructorPattern) subPats) args ++ more)
+          | otherwise -> fk
+        _otherValue -> fk
+    match fk sk ((PatternVar n x, tgt) : more) =
+      match fk (withExtendedEnv n x tgt $ sk) more
 
 doTypeCase :: SrcLoc -> Ty -> [(TypePattern, Core)] -> Eval Value
 doTypeCase blameLoc v0 [] = throwError (EvalErrorCase blameLoc (ValueType v0))

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -281,6 +281,11 @@ doDataCase loc v0 [] = throwError (EvalErrorCase loc v0)
 doDataCase loc v0 ((pat, rhs) : ps) =
   match (doDataCase loc v0 ps) (eval rhs) [(unConstructorPattern pat, v0)]
   where
+    match ::
+      Eval Value {- ^ Failure continuation -} ->
+      Eval Value {- ^ Success continuation, to be used in an extended environment -} ->
+      [(ConstructorPatternF ConstructorPattern, Value)] {- ^ Subpatterns and their scrutinees -} ->
+      Eval Value
     match _fk sk [] = sk
     match fk sk ((CtorPattern ctor subPats, tgt) : more) =
       case tgt of
@@ -289,7 +294,6 @@ doDataCase loc v0 ((pat, rhs) : ps) =
             if length subPats /= length args
               then error $ "Type checker bug: wrong number of pattern vars for constructor " ++ show c
               else match fk sk (zip (map unConstructorPattern subPats) args ++ more)
-          | otherwise -> fk
         _otherValue -> fk
     match fk sk ((PatternVar n x, tgt) : more) =
       match fk (withExtendedEnv n x tgt $ sk) more

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -580,7 +580,7 @@ initializeKernel = do
                   varInfo <- traverse Prims.prepareVar args
                   sch <- trivialScheme tType
                   modifyState $
-                    set (expanderPatternBinders . at (Right dest)) $
+                    set (expanderTypePatternBinders . at dest) $
                     Just [ (sc, n, x, sch)
                          | (sc, n, x) <- varInfo
                          ]
@@ -926,28 +926,58 @@ runTask (tid, localData, task) = withLocal localData $ do
             addConstructor cn dt ctor ts
           linkDeclOutputScopes outScopesDest scs
     AwaitingPattern patPtr ty dest stx -> do
-      ready <-
-        case patPtr of
-          Left pptr -> isJust . view (expanderCompletedPatterns . at pptr) <$> getState
-          Right tptr -> isJust . view (expanderCompletedTypePatterns . at tptr) <$> getState
-      if (not ready)
+      ready <- do
+        let patternComplete ptr =
+              (view (expanderCompletedPatterns . at ptr) <$> getState) >>=
+              \case
+                Nothing ->
+                  pure False
+                Just layer ->
+                  and <$> traverse patternComplete layer
+        patternComplete patPtr
+        -- TODO traverse the tree and get the layers out, collecting the set of pointers to later accumulate the binders
+      if not ready
         then stillStuck tid task
         else do
-            varInfo <- view (expanderPatternBinders . at patPtr) <$> getState
-            case varInfo of
-              Nothing -> throwError $ InternalError "Pattern info not added"
-              Just vars -> do
-                p <- currentPhase
-                let rhs' = foldr (flip (addScope p)) stx
-                             [ sc'
-                             | (sc', _, _, _) <- vars
-                             ]
-                withLocalVarTypes
-                  [ (var, varStx, t)
-                  | (_sc, varStx, var, t) <- vars
-                  ] $
-                  expandOneExpression ty dest rhs'
-
+          let getVarInfo ptr =
+                (view (expanderPatternBinders . at ptr) <$> getState) >>=
+                \case
+                  Nothing ->
+                    throwError $ InternalError "Pattern info not added"
+                  Just (Right found) ->
+                    pure [found]
+                  Just (Left ptrs) ->
+                    concat <$> traverse getVarInfo ptrs
+          vars <- getVarInfo patPtr
+          p <- currentPhase
+          let rhs' = foldr (flip (addScope p)) stx
+                       [ sc'
+                       | (sc', _, _, _) <- vars
+                       ]
+          withLocalVarTypes
+            [ (var, varStx, t)
+            | (_sc, varStx, var, t) <- vars
+            ] $
+            expandOneExpression ty dest rhs'
+    AwaitingTypePattern patPtr ty dest stx -> do
+      ready <- isJust . view (expanderCompletedTypePatterns . at patPtr) <$> getState
+      if not ready
+        then stillStuck tid task
+        else do
+          varInfo <- view (expanderTypePatternBinders . at patPtr) <$> getState
+          case varInfo of
+            Nothing -> throwError $ InternalError "Type pattern info not added"
+            Just vars -> do
+              p <- currentPhase
+              let rhs' = foldr (flip (addScope p)) stx
+                           [ sc'
+                           | (sc', _, _, _) <- vars
+                           ]
+              withLocalVarTypes
+                [ (var, varStx, t)
+                | (_sc, varStx, var, t) <- vars
+                ] $
+                expandOneExpression ty dest rhs'
 
   where
     laterMacro tid' b v x dest deps mdest stx = do
@@ -978,6 +1008,12 @@ runTask (tid, localData, task) = withLocal localData $ do
 
 
 expandOnePattern :: Ty -> Ty -> PatternPtr -> Syntax -> Expand ()
+-- This case means that identifier-only macro invocations aren't valid in pattern contexts
+expandOnePattern _exprTy scrutTy dest var@(Syntax (Stx _ _ (Id _))) = do
+  ty <- trivialScheme scrutTy
+  (sc, x, v) <- Prims.prepareVar var
+  modifyState $ set (expanderPatternBinders . at dest) $ Just $ Right (sc, x, v, ty)
+  linkPattern dest $ PatternVar x v
 expandOnePattern exprTy scrutTy dest stx =
   expandOneForm (PatternDest exprTy scrutTy dest) stx
 
@@ -985,12 +1021,13 @@ expandOneTypePattern :: Ty -> TypePatternPtr -> Syntax -> Expand ()
 expandOneTypePattern exprTy dest stx =
   expandOneForm (TypePatternDest exprTy dest) stx
 
-
 expandOneType :: SplitTypePtr -> Syntax -> Expand ()
 expandOneType dest stx = expandOneForm (TypeDest dest) stx
 
 expandOneExpression :: Ty -> SplitCorePtr -> Syntax -> Expand ()
 expandOneExpression t dest stx = expandOneForm (ExprDest t dest) stx
+
+
 
 -- | Insert a function application marker with a lexical context from
 -- the original expression
@@ -1058,26 +1095,23 @@ expandOneForm prob stx
                   else for (zip args' foundArgs) (uncurry schedule)
               linkExpr dest (CoreCtor ctor argDests)
               saveExprType dest t
-            PatternDest _exprTy patTy dest -> do
-              Stx _ loc (_cname, patVars) <- mustBeCons stx
+            PatternDest exprTy patTy dest -> do
+              Stx _ loc (_cname, subPats) <- mustBeCons stx
               tyArgs <- makeTypeMetas arity
-              argTypes <- for args \ a -> do
-                            t <- inst (Scheme arity a) tyArgs
-                            trivialScheme t
+              argTypes <- for args \ a ->
+                            inst (Scheme arity a) tyArgs
               unify loc (tDatatype dt tyArgs) patTy
-              if length patVars /= length argTypes
-                then throwError $ WrongArgCount stx ctor (length argTypes) (length patVars)
+              if length subPats /= length argTypes
+                then throwError $ WrongArgCount stx ctor (length argTypes) (length subPats)
                 else do
-                  varInfo <- traverse Prims.prepareVar patVars
-                  modifyState $
-                    set (expanderPatternBinders . at (Left dest)) $
-                    Just [ (sc, name, x, t)
-                         | ((sc, name, x), t) <- zip varInfo argTypes
-                         ]
+                  subPtrs <- for (zip subPats argTypes) \(sp, t) -> do
+                    ptr <- liftIO newPatternPtr
+                    let subPatDest = PatternDest exprTy t ptr
+                    forkExpandSyntax subPatDest sp
+                    pure ptr
+                  modifyState $ set (expanderPatternBinders . at dest) $ Just $ Left subPtrs
                   linkPattern dest $
-                    ConstructorPattern ctor [ (varStx, var)
-                                            | (_, varStx, var) <- varInfo
-                                            ]
+                    CtorPattern ctor subPtrs
             other ->
               throwError $ WrongMacroContext stx ExpressionCtx (problemContext other)
         EPrimModuleMacro _ ->

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -959,7 +959,7 @@ runTask (tid, localData, task) = withLocal localData $ do
             ] $
             expandOneExpression ty dest rhs'
     AwaitingTypePattern patPtr ty dest stx -> do
-      ready <- isJust . view (expanderCompletedTypePatterns . at patPtr) <$> getState
+      ready <- has (expanderCompletedTypePatterns . ix patPtr) <$> getState
       if not ready
         then stillStuck tid task
         else do

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -935,7 +935,6 @@ runTask (tid, localData, task) = withLocal localData $ do
                 Just layer ->
                   and <$> traverse patternComplete layer
         patternComplete patPtr
-        -- TODO traverse the tree and get the layers out, collecting the set of pointers to later accumulate the binders
       if not ready
         then stillStuck tid task
         else do

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -131,6 +131,7 @@ module Expander.Monad
   , expanderModuleTop
   , expanderOriginLocations
   , expanderPatternBinders
+  , expanderTypePatternBinders
   , expanderVarTypes
   , expanderTasks
   , expanderWorld
@@ -267,9 +268,10 @@ data ExpanderState = ExpanderState
   , _expanderTasks :: [(TaskID, ExpanderLocal, ExpanderTask)]
   , _expanderOriginLocations :: !(Map.Map SplitCorePtr SrcLoc)
   , _expanderCompletedCore :: !(Map.Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr))
-  , _expanderCompletedPatterns :: !(Map.Map PatternPtr ConstructorPattern)
+  , _expanderCompletedPatterns :: !(Map.Map PatternPtr (ConstructorPatternF PatternPtr))
   , _expanderCompletedTypePatterns :: !(Map.Map TypePatternPtr TypePattern)
-  , _expanderPatternBinders :: !(Map.Map (Either PatternPtr TypePatternPtr) [(Scope, Ident, Var, SchemePtr)])
+  , _expanderPatternBinders :: !(Map.Map PatternPtr (Either [PatternPtr] (Scope, Ident, Var, SchemePtr)))
+  , _expanderTypePatternBinders :: !(Map.Map TypePatternPtr [(Scope, Ident, Var, SchemePtr)])
   , _expanderCompletedTypes :: !(Map.Map SplitTypePtr (TyF SplitTypePtr))
   , _expanderCompletedDeclTrees :: !(Map.Map DeclTreePtr (DeclTreeF DeclPtr DeclTreePtr))
   , _expanderCompletedDecls :: !(Map.Map DeclPtr (Decl SplitTypePtr SchemePtr DeclTreePtr SplitCorePtr))
@@ -307,6 +309,7 @@ initExpanderState = ExpanderState
   , _expanderCompletedPatterns = Map.empty
   , _expanderCompletedTypePatterns = Map.empty
   , _expanderPatternBinders = Map.empty
+  , _expanderTypePatternBinders = Map.empty
   , _expanderCompletedTypes = Map.empty
   , _expanderCompletedDeclTrees = Map.empty
   , _expanderCompletedDecls = Map.empty
@@ -412,7 +415,7 @@ linkExpr :: SplitCorePtr -> CoreF TypePatternPtr PatternPtr SplitCorePtr -> Expa
 linkExpr dest layer =
   modifyState $ over expanderCompletedCore (<> Map.singleton dest layer)
 
-linkPattern :: PatternPtr -> ConstructorPattern -> Expand ()
+linkPattern :: PatternPtr -> ConstructorPatternF PatternPtr -> Expand ()
 linkPattern dest pat =
   modifyState $ over expanderCompletedPatterns (<> Map.singleton dest pat)
 

--- a/src/Expander/Task.hs
+++ b/src/Expander/Task.hs
@@ -52,7 +52,8 @@ data ExpanderTask
   | ExpandVar Ty SplitCorePtr Syntax Var
     -- ^ Expected type, destination, origin syntax, and variable to use if it's acceptable
   | EstablishConstructors ScopeSet DeclOutputScopesPtr Datatype [(Ident, Constructor, [SplitTypePtr])]
-  | AwaitingPattern (Either PatternPtr TypePatternPtr) Ty SplitCorePtr Syntax
+  | AwaitingPattern PatternPtr Ty SplitCorePtr Syntax
+  | AwaitingTypePattern TypePatternPtr Ty SplitCorePtr Syntax
   deriving (Show)
 
 data AfterTypeTask
@@ -102,6 +103,7 @@ instance ShortShow ExpanderTask where
   shortShow (ExpandVar t d x v) = "(ExpandVar " ++ show t ++ " " ++ show d ++ " " ++ show x ++ " " ++ show v ++ ")"
   shortShow (EstablishConstructors _ _ dt _) = "(EstablishConstructors " ++ show dt ++ ")"
   shortShow (AwaitingPattern _ _ _ _) = "(AwaitingPattern _ _ _ _)"
+  shortShow (AwaitingTypePattern _ _ _ _) = "(AwaitingTypePattern _ _ _ _)"
 
 instance Pretty VarInfo ExpanderTask where
   pp _ task = string (shortShow task)

--- a/src/PartialCore.hs
+++ b/src/PartialCore.hs
@@ -5,19 +5,27 @@ import Control.Lens
 
 import Core
 
+newtype PartialPattern =
+  PartialPattern { unPartialPattern :: Maybe (ConstructorPatternF PartialPattern) }
+  deriving (Eq, Show)
 
 newtype PartialCore = PartialCore
   { unPartialCore ::
-      Maybe (CoreF (Maybe TypePattern) (Maybe ConstructorPattern) PartialCore)
+      Maybe (CoreF (Maybe TypePattern) PartialPattern PartialCore)
   }
   deriving (Eq, Show)
 makePrisms ''PartialCore
 
 nonPartial :: Core -> PartialCore
 nonPartial =
-  PartialCore . Just . mapCoreF Just Just nonPartial . unCore
-
+  PartialCore . Just . mapCoreF Just nonPartialPattern nonPartial . unCore
+  where
+    nonPartialPattern pat = PartialPattern $ Just $ nonPartialPattern <$> view constructorPattern pat
 
 runPartialCore :: PartialCore -> Maybe Core
 runPartialCore (PartialCore Nothing) = Nothing
-runPartialCore (PartialCore (Just c)) = Core <$> traverseCoreF id id runPartialCore c
+runPartialCore (PartialCore (Just c)) = Core <$> traverseCoreF id runPartialPattern runPartialCore c
+
+runPartialPattern :: PartialPattern -> Maybe ConstructorPattern
+runPartialPattern (PartialPattern Nothing) = Nothing
+runPartialPattern (PartialPattern (Just p)) = ConstructorPattern <$> traverse runPartialPattern p

--- a/src/PartialCore.hs
+++ b/src/PartialCore.hs
@@ -20,7 +20,7 @@ nonPartial :: Core -> PartialCore
 nonPartial =
   PartialCore . Just . mapCoreF Just nonPartialPattern nonPartial . unCore
   where
-    nonPartialPattern pat = PartialPattern $ Just $ nonPartialPattern <$> view constructorPattern pat
+    nonPartialPattern pat = PartialPattern $ Just $ nonPartialPattern <$> unConstructorPattern pat
 
 runPartialCore :: PartialCore -> Maybe Core
 runPartialCore (PartialCore Nothing) = Nothing

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -210,7 +210,7 @@ instance PrettyBinder VarInfo TypePattern where
     ppBind env (BinderPair (ident, x))
 
 instance PrettyBinder VarInfo ConstructorPattern where
-  ppBind env pat = ppBind env (view constructorPattern pat)
+  ppBind env pat = ppBind env (unConstructorPattern pat)
 
 instance PrettyBinder VarInfo a => PrettyBinder VarInfo (ConstructorPatternF a) where
   ppBind env (CtorPattern ctor subPats) =

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -210,19 +210,18 @@ instance PrettyBinder VarInfo TypePattern where
     ppBind env (BinderPair (ident, x))
 
 instance PrettyBinder VarInfo ConstructorPattern where
-  ppBind env (ConstructorPattern ctor vars) =
-    case vars of
+  ppBind env pat = ppBind env (view constructorPattern pat)
+
+instance PrettyBinder VarInfo a => PrettyBinder VarInfo (ConstructorPatternF a) where
+  ppBind env (CtorPattern ctor subPats) =
+    case subPats of
       [] -> (pp env ctor, Env.empty)
-      more ->
-        let env' = foldr (\(x, v) e -> Env.insert x v () e)
-                   Env.empty
-                   [ (v, x) | (x, v) <- more ]
-        in (pp env ctor <+>
-             hsep [ annotate (BindingSite v) (text x)
-                  | (Stx _ _ x, v) <- more
-                  ],
+      _nonEmpty ->
+        let subDocs = map (ppBind env) subPats
+            env' = foldr (<>) Env.empty (map snd subDocs)
+        in (pp env ctor <+> hsep (map fst subDocs),
             env')
-  ppBind _env (AnyConstructor ident@(Stx _ _ n) x) =
+  ppBind _env (PatternVar ident@(Stx _ _ n) x) =
     (annotate (BindingSite x) (text n), Env.singleton x ident ())
 
 instance PrettyBinder VarInfo SyntaxPattern where


### PR DESCRIPTION
Fixes #107.

Macros in pattern position complicate the semantics a little bit,
because pattern variables are lexically identical to any other kind of
identifier. There's no easy way to tell whether a user intends to
shadow an existing macro with a pattern variable or to invoke that
macro in a pattern position.

The solution here is perhaps overly simplistic: bare identifiers in
pattern position are ALWAYS pattern variables - even if they share a
name with a constructor or a macro. The rule is simple, but not very
flexible.

Other alternative approaches could include:

 1. Lexically distinguish pattern variables from other identifiers,
 e.g. by wrapping them in <> or requiring them to start or end with a
 given character. This is the Haskell/Idris approach.

 2. Have some more rules to check for exisiting bindings, and specify
 when they override the local binding. This is the Agda approach.

 3. Allow macros to specify at binding time whether they should be
 considered in pattern contexts, or not. This is the Racket approach (see
 define-match-expander).

I think that any of those can build on top of this basic run-time
support for deep patterns, as well as the expander's handling of
bindings and the like. Our experience in Idris, which went from option
2 to option 1 a few years back, was that simple rules were better than
more flexible yet more complicated rules.