### PR TITLE
make Hedgehog tests 10 times faster

### DIFF
--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -59,10 +59,10 @@ tests goldenTests = testGroup "All tests"
   [ testGroup "Expander tests" [ operationTests, miniTests, moduleTests ]
   , testGroup "Hedgehog tests" [ testProperty
                                    "runPartialCore . nonPartial = id"
-                                   propRunPartialCoreNonPartial
+                                   (withTests 10 propRunPartialCoreNonPartial)
                                , testProperty
                                    "unsplit . split = pure"
-                                   propSplitUnsplit
+                                   (withTests 10 propSplitUnsplit)
                                ]
   , goldenTests
   ]


### PR DESCRIPTION
by running 10 times less tests. these take a lot more time to run than
all our other tests, so reducing those makes interactively running the
tests a lot more pleasant.