### PR TITLE
fix golden tests and lambda case

### DIFF
--- a/examples/lambda-case-test.golden
+++ b/examples/lambda-case-test.golden
@@ -1,0 +1,2 @@
+#[lambda-case-test.kl:8.13-8.16]<nil> : Syntax
+#[lambda-case-test.kl:9.16-9.20]<cons> : Syntax

--- a/examples/lambda-case-test.kl
+++ b/examples/lambda-case-test.kl
@@ -1,0 +1,12 @@
+#lang "prelude.kl"
+
+(import "lambda-case.kl")
+(import "list.kl")
+
+(define classify
+  (lambda-case
+    [(nil) 'nil]
+    [(:: a b) 'cons]))
+
+(example (classify (nil)))
+(example (classify (:: 1 (:: 2 (nil)))))

--- a/examples/lambda-case.kl
+++ b/examples/lambda-case.kl
@@ -7,9 +7,16 @@
   ([lambda-case
     (lambda (stx)
       (syntax-case stx
-        [(list (_ cases))
+        [(cons _ cases)
          (pure
-          (quasiquote/loc stx
-            (lambda (x) (case x ,cases))))]))]))
+           (list-syntax
+             ('lambda
+              '(x)
+              (cons-list-syntax 'case
+                (cons-list-syntax 'x
+                  cases
+                  stx)
+                stx))
+             stx))]))]))
 
 (export lambda-case)

--- a/examples/monad.kl
+++ b/examples/monad.kl
@@ -1,7 +1,6 @@
 #lang "prelude.kl"
 
 (import "defun.kl")
-(import "lambda-case.kl")
 (import (shift "prelude.kl" 1))
 (import (shift "let.kl" 1))
 (import (shift "quasiquote.kl" 1))

--- a/tests/Golden.hs
+++ b/tests/Golden.hs
@@ -13,6 +13,7 @@ import Control.Monad.Trans.Writer (WriterT, execWriterT, tell)
 import Data.Foldable (for_)
 import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy as T
+import System.Directory (doesFileExist)
 import System.FilePath (replaceExtension, takeBaseName)
 import Test.Tasty.HUnit (assertFailure, testCase)
 import Test.Tasty (TestTree, testGroup)
@@ -42,6 +43,10 @@ mkGoldenTests = do
   return $ testGroup "Golden tests"
     [ testCase testName $ do
         actual <- execWriterT $ runExamples klisterFile
+        firstRun <- not <$> doesFileExist goldenFile
+        when firstRun $ do
+          putStrLn $ "first run: creating " ++ goldenFile
+          Text.writeFile goldenFile actual
         expected <- Text.readFile goldenFile
         when (actual /= expected) $ do
           assertFailure . Text.unpack


### PR DESCRIPTION
the existing implementation of lambda-case was strangely-limited: only a single pattern-rhs pair was allowed. with this PR, several are now allowed.

I added a new file to test this feature, and in doing so, I found a flaw in my reimplementation of the golden tests accidentally dropped an important feature: generating the golden files when they don't yet exist. this PR fixes that too.