### PR TITLE
explain lambda-case and mega-const

### DIFF
--- a/examples/lambda-case.kl
+++ b/examples/lambda-case.kl
@@ -4,6 +4,14 @@
 (import (shift "quasiquote.kl" 1))
 
 (define-macros
+  -- (lambda-case
+  --   [(nil) 'nil]
+  --   [(:: a b) 'cons])
+  -- =>
+  -- (lambda (x)
+  --   (case x
+  --     [(nil) 'nil]
+  --     [(:: a b) 'cons]))
   ([lambda-case
     (lambda (stx)
       (syntax-case stx

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -22,6 +22,9 @@
            ((m) true)))
 
 
+-- (the (-> Bool Bool Bool Bool Unit) (mega-const unit))
+-- =>
+-- (the (-> Bool Bool Bool Bool Unit) (lambda (_ _ _ _) unit))
 (define-macro (mega-const e)
   (>>= (which-problem)
        (lambda (prob)


### PR DESCRIPTION
I added two comments, each explaining what a macros does using a commented-out example of what _code_ the macro expands to.

Doing so made me realize that the `(example <expr>)` form has two flaws. First, since the output is in the golden file, it is cumbersome for the reader to jump between the example and its output. I think I would prefer `(example <expr> <expected-output>)`, similarly to [`check-equal?`](https://docs.racket-lang.org/rackunit/api.html?q=syntax-%3E#%28def._%28%28lib._rackunit%2Fmain..rkt%29._check-equal~3f%29%29).

Second, if `(<macro> <args>)` outputs `(f 1 2 3)`, then `(example (<macro> <args>))` outputs the result of the call `(f 1 2 3)`, not the code `'(f 1 2 3)`. When giving an example of what a macro does, like I did in those two comments, showing the code is often more helpful. I think we should thus have a variant of `example` which does that.