### PR TITLE
interpret ",@" as unquote-splicing

### DIFF
--- a/examples/quasiquote-syntax-test.golden
+++ b/examples/quasiquote-syntax-test.golden
@@ -1,8 +1,12 @@
-#[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
-#[quasiquote-syntax-test.kl:8.11-8.16]<thing> : Syntax
-#[quasiquote-syntax-test.kl:5.16-5.23]<nothing> : Syntax
-#[quasiquote-syntax-test.kl:11.11-11.18]<(thing)> : Syntax
-#[quasiquote-syntax-test.kl:12.11-12.19]<(nothing)> : Syntax
-#[quasiquote-syntax-test.kl:14.11-14.45]<(list-syntax (nothing thing) thing)> : Syntax
-#[quasiquote-syntax-test.kl:16.11-16.48]<(list-syntax (nothing thing ()) thing)> : Syntax
-#[quasiquote-syntax-test.kl:18.11-18.31]<(thing nothing thing)> : Syntax
+#[quasiquote-syntax-test.kl:6.4-8.29]
+ <((quasiquote (is quasiquote))
+   (unquote (is unquote))
+   (unquote-splicing (is unquote-splicing)))> : Syntax
+#[quasiquote-syntax-test.kl:11.16-11.23]<nothing> : Syntax
+#[quasiquote-syntax-test.kl:14.11-14.16]<thing> : Syntax
+#[quasiquote-syntax-test.kl:11.16-11.23]<nothing> : Syntax
+#[quasiquote-syntax-test.kl:17.11-17.18]<(thing)> : Syntax
+#[quasiquote-syntax-test.kl:18.11-18.19]<(nothing)> : Syntax
+#[quasiquote-syntax-test.kl:20.11-20.45]<(list-syntax (nothing thing) thing)> : Syntax
+#[quasiquote-syntax-test.kl:22.11-22.48]<(list-syntax (nothing thing ()) thing)> : Syntax
+#[quasiquote-syntax-test.kl:24.11-24.31]<(thing nothing thing)> : Syntax

--- a/examples/quasiquote-syntax-test.kl
+++ b/examples/quasiquote-syntax-test.kl
@@ -1,18 +1,18 @@
 #lang "prelude.kl"
 
-[import "quasiquote.kl"]
+(import "quasiquote.kl")
 
-[define thing 'nothing]
+(define thing 'nothing)
 
-[example thing]
-[example `thing]
-[example `,thing]
+(example thing)
+(example `thing)
+(example `,thing)
 
-[example `[thing]]
-[example `[,thing]]
+(example `(thing))
+(example `(,thing))
 
-[example `[list-syntax [,thing thing] thing]]
+(example `(list-syntax (,thing thing) thing))
 
-[example `[list-syntax [,thing thing ()] thing]]
+(example `(list-syntax (,thing thing ()) thing))
 
-[example `(thing ,thing thing)]
+(example `(thing ,thing thing))

--- a/examples/quasiquote-syntax-test.kl
+++ b/examples/quasiquote-syntax-test.kl
@@ -2,6 +2,12 @@
 
 (import "quasiquote.kl")
 
+(define special-characters
+  '(`(is quasiquote)
+    ,(is unquote)
+    ,@(is unquote-splicing)))
+(example special-characters)
+
 (define thing 'nothing)
 
 (example thing)

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -42,7 +42,7 @@ readExpr filename fileContents =
     Right ok -> Right ok
 
 expr :: Parser Syntax
-expr = list <|> ident <|> integer <|> string <|> quoted <|> quasiquoted <|> unquoted
+expr = list <|> ident <|> integer <|> string <|> quoted <|> quasiquoted <|> unquote_spliced <|> unquoted
 
 ident :: Parser Syntax
 ident =
@@ -110,6 +110,14 @@ unquoted =
             , e
             ]
 
+unquote_spliced :: Parser Syntax
+unquote_spliced =
+  do Located loc1 _ <- lexeme (literal ",@")
+     e@(Syntax (Stx _ loc2 _)) <- expr
+     return $ Syntax $ Stx ScopeSet.empty (spanLocs loc1 loc2) $
+       List [ Syntax (Stx ScopeSet.empty loc1 (Id "unquote-splicing"))
+            , e
+            ]
 
 -- | Mostly like the identifier rules from R6RS Scheme, minus hex escapes
 identName :: Parser Text

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -285,7 +285,7 @@ moduleTests = testGroup "Module tests" [ shouldWork, shouldn'tWork ]
           , \m _ ->
               view moduleBody m & map (view completeDecl) &
               \case
-                (Import _ : Define _ _ _ thingDef : examples) -> do
+                (Import _ : _ : _ : Define _ _ _ thingDef : examples) -> do
                   case thingDef of
                     Core (CoreSyntax (Syntax (Stx _ _ (Id "nothing")))) ->
                       case examples of


### PR DESCRIPTION
quasiquote does not yet make use of this syntax, but it's a first step in that direction.