### PR TITLE
Fix variable binding in type patterns

### DIFF
--- a/examples/which-problem.golden
+++ b/examples/which-problem.golden
@@ -7,3 +7,4 @@
 "String" : String
 "String -> String" : String
 "String -> String -> String" : String
+"(String -> String) -> String" : String

--- a/examples/which-problem.golden
+++ b/examples/which-problem.golden
@@ -6,4 +6,4 @@
 (both #<closure> #<closure>) : ∀(α : *) (β : *) (γ : *). (Both (α → (β → (γ → Syntax))))
 "String" : String
 "String -> String" : String
-"String -> String" : String
+"String -> String -> String" : String

--- a/examples/which-problem.golden
+++ b/examples/which-problem.golden
@@ -4,4 +4,6 @@
 #<closure> : (Bool → (Bool → (Bool → (Bool → Unit))))
 (both #<closure> #<closure>) : ∀(α : *) (β : *) (γ : *). (Both (α → (β → (γ → Syntax))))
 (both #<closure> #<closure>) : ∀(α : *) (β : *) (γ : *). (Both (α → (β → (γ → Syntax))))
-"string" : String
+"String" : String
+"String -> String" : String
+"String -> String" : String

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -54,8 +54,8 @@
 
 -- Regression test for a bug where matching on String didn't work.
 --
--- Now also a demonstration of a separate bug where matching on (-> a b)
--- binds the same type to both 'a' and 'b'.
+-- Also acts as a regression test for a bug where the pattern (-> a b)
+-- was binding the same type to both a and b.
 (define-macro (type-name)
   (flet (render-type (in-lhs type)
           (type-case type
@@ -85,4 +85,4 @@
 
 (example (the String (type-name)))
 (example (the String ((type-name) "foo")))
-(example (the String ((type-name) "foo" "bar")))  -- should be "String -> String -> String", but is "String -> String"
+(example (the String ((type-name) "foo" "bar")))

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -52,16 +52,37 @@
 (example (both (lambda (x) (lambda (y) (lambda (z) 'hello))) (mega-const 'world)))
 (example (both (mega-const 'hello) (lambda (x) (lambda (y) (lambda (z) 'world)))))
 
--- regression test for a bug where matching on String didn't work
+-- Regression test for a bug where matching on String didn't work.
+--
+-- Now also a demonstration of a separate bug where matching on (-> a b)
+-- binds the same type to both 'a' and 'b'.
 (define-macro (type-name)
-  (>>= (which-problem)
-       (lambda (prob)
-         (case prob
-           [(expression t)
-            (type-case t
-              [(-> a b)
-               (pure '"arrow")]
-              [String
-               (pure '"string")])]))))
+  (flet (render-type (in-lhs type)
+          (type-case type
+            [(-> type1 type2)
+             (>>= (render-type true type1)
+                  (lambda (string1)
+                    (>>= (render-type false type2)
+                         (lambda (string2)
+                           (let (r (string-append string1
+                                     (string-append " -> " string2)))
+                             (case in-lhs
+                               [(true)
+                                (pure (string-append "("
+                                        (string-append r ")")))]
+                               [(false)
+                                 (pure r)]))))))]
+            [String
+             (pure "String")]))
+    (>>= (which-problem)
+         (lambda (prob)
+           (case prob
+             [(expression t)
+              (>>= (render-type false t)
+                   (lambda (string)
+                     (let (syntax (close-syntax '() '() (string-contents string)))
+                       (pure `(mega-const ,syntax)))))])))))
 
 (example (the String (type-name)))
+(example (the String ((type-name) "foo")))
+(example (the String ((type-name) "foo" "bar")))  -- should be "String -> String -> String", but is "String -> String"

--- a/examples/which-problem.kl
+++ b/examples/which-problem.kl
@@ -86,3 +86,4 @@
 (example (the String (type-name)))
 (example (the String ((type-name) "foo")))
 (example (the String ((type-name) "foo" "bar")))
+(example (the String ((type-name) (lambda (x) (the String x)))))

--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -309,8 +309,10 @@ doTypeCase blameLoc (Ty v0) ((p, rhs0) : ps) = match (doTypeCase blameLoc (Ty v0
 
         (TyF ctor1 args1, TyF ctor2 args2)
           | ctor1 == ctor2 && length args1 == length args2 ->
-            withManyExtendedEnv [(n, x, ValueType arg) | (n, x) <- args1, arg <- args2] $
-            eval rhs
+            withManyExtendedEnv [ (n, x, ValueType arg)
+                                | (n, x) <- args1
+                                | arg <- args2]
+                                (eval rhs)
         (_, _) -> next
     match _next (AnyType n x) rhs scrut =
       withExtendedEnv n x (ValueType (Ty scrut)) (eval rhs)


### PR DESCRIPTION
When using the pattern `(-> a b)`, both `a` and `b` were bound to the same type! The cause was using list comprehension instead of parallel list comprehension (`[(x,y) | x <- ..., y <- ...]` instead of `[(x,y) | x <- ... | y <- ...]`), thus resulting in the list `[(x1,y1), (x1,y2), (x2,y1), (x2,y2)]` instead of `[(x1,y1), (x2,y2)]`.