### PR TITLE
bugfix: bind-IO only ran the first IO action

### DIFF
--- a/examples/hello.golden
+++ b/examples/hello.golden
@@ -1,0 +1,2 @@
+hello
+world

--- a/examples/hello.kl
+++ b/examples/hello.kl
@@ -1,0 +1,16 @@
+#lang "prelude.kl"
+
+-- do notation is not builtin syntax, it's implemented as a library!
+(import "monad.kl")
+
+-- (-> String (IO Unit))
+(defun putStrLn (str)
+  (write stdout (string-append str "\n")))
+
+-- "run" is like main, except you can have more than one.
+(run
+  -- Klister doesn't have typeclasses yet, so "do" needs an explicit
+  -- dictionary argument.
+  (do io-monad
+    (putStrLn "hello")
+    (putStrLn "world")))

--- a/examples/monad.kl
+++ b/examples/monad.kl
@@ -26,6 +26,13 @@
         [(nothing) (nothing)]
         [(just x) (just (f x))]))))
 
+(define io-functor
+  (functor
+    (lambda (f io-x)
+      (bind-IO io-x
+        (lambda (x)
+          (pure-IO (f x)))))))
+
 (define macro-functor
   (functor
     (lambda (f x)
@@ -64,6 +71,17 @@
          (case arg
            ((nothing) (nothing))
            ((just x) (just (f x)))))))))
+
+(define io-applicative
+  (applicative
+    io-functor
+    pure-IO
+    (lambda (io-f io-x)
+      (bind-IO io-f
+        (lambda (f)
+          (bind-IO io-x
+            (lambda (x)
+              (pure-IO (f x)))))))))
 
 (define return
   (lambda (inst x)
@@ -142,6 +160,11 @@
       (case m
         ((nothing) (nothing))
         ((just x) (f x))))))
+
+(define io-monad
+  (monad
+    io-applicative
+    bind-IO))
 
 (define bind
   (lambda (inst m f)
@@ -226,5 +249,6 @@
   Applicative applicative return ap idiom define-idiom
   Monad monad monad->applicative bind do <- define-do
   macro-functor macro-applicative macro-monad
+  io-functor io-applicative io-monad
   maybe-functor maybe-applicative perhaps maybe-monad
   list-functor)

--- a/examples/monad.kl
+++ b/examples/monad.kl
@@ -226,4 +226,5 @@
   Applicative applicative return ap idiom define-idiom
   Monad monad monad->applicative bind do <- define-do
   macro-functor macro-applicative macro-monad
-  maybe-functor maybe-applicative perhaps maybe-monad)
+  maybe-functor maybe-applicative perhaps maybe-monad
+  list-functor)

--- a/examples/monad.kl
+++ b/examples/monad.kl
@@ -11,10 +11,6 @@
 (datatype (Functor F A B)
   (functor (-> (-> A B) (-> (F A) (F B)))))
 
-(datatype (List A)
-  (nil)
-  (:: A (List A)))
-
 (defun map (f xs)
   (case xs
     [(nil) (nil)]
@@ -22,10 +18,6 @@
 
 (define list-functor
   (functor map))
-
-(datatype (Maybe A)
-  (nothing)
-  (just A))
 
 (define maybe-functor
   (functor
@@ -234,4 +226,4 @@
   Applicative applicative return ap idiom define-idiom
   Monad monad monad->applicative bind do <- define-do
   macro-functor macro-applicative macro-monad
-  Maybe nothing just maybe-functor maybe-applicative perhaps maybe-monad)
+  maybe-functor maybe-applicative perhaps maybe-monad)


### PR DESCRIPTION
The issue was that given `bind-IO iox f`, we were basically executing

    do x <- iox
       pure (f x)

instead of

    do x <- iox
       f x

It's actually worse than that: we were returning the IO action returned by `f x` to a caller which expects a `b`, not an `IO b`. So this could easily have crashed the program, if we ever wrote a program which actually did something with the result of `bind-IO`.

In practice, however, most of our tests are about expressions, not IO actions, so we didn't catch this earlier. The one test which did use `bind-IO` was [io.kl](https://github.com/gelisam/klister/blob/main/examples/io.kl#L5), but it only checked that the result was inferred to have type IO Integer, it did not execute the resulting IO action.