### PR TITLE
remove unused 'oops' and 'ident' primitives

### DIFF
--- a/src/Evaluator.hs
+++ b/src/Evaluator.hs
@@ -151,11 +151,6 @@ eval (Core (CoreSyntax syntax)) = do
 eval (Core (CoreCase loc scrutinee cases)) = do
   v <- eval scrutinee
   doCase loc v cases
-eval (Core (CoreIdentifier (Stx scopeSet srcLoc name))) = do
-  pure $ ValueSyntax
-       $ Syntax
-       $ Stx scopeSet srcLoc
-       $ Id name
 eval (Core (CoreIdent (ScopedIdent ident scope))) = do
   identSyntax <- evalAsSyntax ident
   case identSyntax of

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -641,7 +641,6 @@ initializeKernel outputChannel = do
       , ("bound-identifier=?", Prims.identEqual Bound)
       , ("free-identifier=?", Prims.identEqual Free)
       , ("quote", Prims.quote)
-      , ("ident", Prims.ident)
       , ("ident-syntax", Prims.identSyntax)
       , ("empty-list-syntax", Prims.emptyListSyntax)
       , ("cons-list-syntax", Prims.consListSyntax)

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -627,8 +627,7 @@ initializeKernel outputChannel = do
 
     exprPrims :: [(Text, Ty -> SplitCorePtr -> Syntax -> Expand ())]
     exprPrims =
-      [ ("oops", Prims.oops)
-      , ("error", Prims.err)
+      [ ("error", Prims.err)
       , ("the", Prims.the)
       , ("let", Prims.letExpr)
       , ("flet", Prims.flet)

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -25,7 +25,6 @@ module Expander.Primitives
   , emptyListSyntax
   , err
   , flet
-  , ident
   , identEqual
   , identSyntax
   , lambda
@@ -366,13 +365,6 @@ quote t dest stx = do
   unify dest t tSyntax
   Stx _ _ (_, quoted) <- mustHaveEntries stx
   linkExpr dest $ CoreSyntax quoted
-
-ident :: ExprPrim
-ident t dest stx = do
-  unify dest t tSyntax
-  Stx _ _ (_, someId) <- mustHaveEntries stx
-  x@(Stx _ _ _) <- mustBeIdent someId
-  linkExpr dest $ CoreIdentifier x
 
 identSyntax :: ExprPrim
 identSyntax t dest stx = do

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -37,7 +37,6 @@ module Expander.Primitives
   , makeIntroducer
   , Expander.Primitives.log
   , whichProblem
-  , oops
   , pureMacro
   , quote
   , replaceLoc
@@ -227,9 +226,6 @@ group expandDeclForms dest outScopesDest stx = do
 
 -- Expression primitives
 type ExprPrim = Ty -> SplitCorePtr -> Syntax -> Expand ()
-
-oops :: ExprPrim
-oops _t _dest stx = throwError (InternalError $ "oops" ++ show stx)
 
 err :: ExprPrim
 err _t dest stx = do

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -163,7 +163,6 @@ instance (PrettyBinder VarInfo typePat, PrettyBinder VarInfo pat, Pretty VarInfo
            in group (group (b <+> "=>") <> line <> pp (env <> env') body)
          | (pat, body) <- pats
          ]
-  pp _env (CoreIdentifier x) = viaShow x
   pp _env (CoreInteger s) = viaShow s
   pp env (CoreIdent x) = pp env x
   pp env (CoreEmpty e) = pp env e

--- a/stdlib/prelude.kl
+++ b/stdlib/prelude.kl
@@ -44,7 +44,6 @@
         Syntax-Contents list-contents integer-contents string-contents identifier-contents
 
         -- primitive expression macros
-        oops
         error
         the
         let
@@ -59,7 +58,6 @@
         bound-identifier=?
         free-identifier=?
         quote
-        ident
         ident-syntax
         empty-list-syntax
         cons-list-syntax

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -130,7 +130,7 @@ miniTests =
             \                {- [[lambda [x] body] e] -} \n\
             \                [pure [list-syntax \n\
             \                        [[list-syntax \n\
-            \                           [[ident lambda] \n\
+            \                           [[ident-syntax 'lambda stx] \n\
             \                            [list-syntax [x] stx] \n\
             \                            body] \n\
             \                           stx] \n\
@@ -661,7 +661,6 @@ genCoreF subgen varGen =
         -- , CoreIdentEq _ <$> sameVars <*> sameVars
         -- , CoreSyntax Syntax
         -- , CoreCase sameVars [(Pattern, core)]
-        -- , CoreIdentifier Ident
         -- , CoreDataCase core [(ConstructorPattern, core)]
         -- , CoreIdent (ScopedIdent core)
         -- , CoreEmpty (ScopedEmpty core)


### PR DESCRIPTION
Closes #173 and #176 