### PR TITLE
Expand bounds to allow tests to pass with GHC 9.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,14 @@ jobs:
       matrix:
         include:
             # latest GHC, default OS
-          - cabal: "3.4"
-            ghc: "9.0.1"
+          - cabal: "3.6"
+            ghc: "9.2.5"
             os: ubuntu-latest
 
             # non-latest GHC, default OS
+          - cabal: "3.4"
+            ghc: "9.0.1"
+            os: ubuntu-latest
           - cabal: "3.2"
             ghc: "8.10.2"
             os: ubuntu-latest

--- a/klister.cabal
+++ b/klister.cabal
@@ -24,7 +24,7 @@ source-repository head
 
 common deps
   build-depends:
-    base                 >= 4.12.0 && < 4.16,
+    base                 >= 4.12.0 && < 4.17,
     bifunctors           >= 5.5.5 && < 5.6,
     containers           >= 0.6 && < 0.7,
     directory            >= 1.3.3 && < 1.4,
@@ -114,11 +114,11 @@ test-suite klister-tests
   ghc-options: -Wall
   build-depends:
     call-stack ^>= 0.1,
-    hedgehog ^>= 1.0,
+    hedgehog >= 1.0 && < 1.4,
     klister,
     silently ^>= 1.2,
     tasty ^>= 1.2,
     tasty-golden ^>= 2.3,
-    tasty-hedgehog ^>= 1.0,
+    tasty-hedgehog >= 1.0 && < 1.5,
     tasty-hunit ^>= 0.10
   default-language: Haskell2010

--- a/klister.cabal
+++ b/klister.cabal
@@ -8,7 +8,7 @@ author:         David Christiansen <david@davidchristiansen.dk>,  Samuel Géline
 maintainer:     David Christiansen <david@davidchristiansen.dk>,  Samuel Gélineau <gelisam@gmail.com>
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC==8.6.5, GHC==8.8.4, GHC==8.10.2, GHC==9.0.1
+tested-with:    GHC==8.6.5, GHC==8.8.4, GHC==8.10.2, GHC==9.0.1, GHC==9.2.5
 build-type:     Simple
 data-files:
     stdlib/builtins.kl


### PR DESCRIPTION
This allowed me to navigate the code locally with HLS, making it much easier to look at a recent PR.