### PR TITLE
testsuite: test all examples, use tasty-golden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+env:
+  KLISTERPATH: ${{ github.workspace }}/examples
+
 jobs:
   cabal:
     name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
@@ -62,6 +65,10 @@ jobs:
     - name: Build
       run: |
         cabal build all
+
+    - name: Path
+      run: |
+        echo "$KLISTERPATH"
 
     - name: Test
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:
+    ./
+
+tests: True

--- a/examples/failing-examples/bound-vs-free.golden
+++ b/examples/failing-examples/bound-vs-free.golden
@@ -1,0 +1,2 @@
+Syntax error from macro:
+    #[bound-vs-free.kl:20.39-20.67]<"variables must be distinct">

--- a/examples/failing-examples/bound-vs-free.kl
+++ b/examples/failing-examples/bound-vs-free.kl
@@ -24,4 +24,4 @@
 (example ((lambda2 _ y 'result) 1 2))
 (example ((lambda2 x _ 'result) 1 2))
 (example ((lambda2 x y 'result) 1 2))
---(example ((lambda2 x x 'result) 1 2))  -- variables must be distinct
+(example ((lambda2 x x 'result) 1 2))  -- variables must be distinct

--- a/examples/failing-examples/incorrect-context.golden
+++ b/examples/failing-examples/incorrect-context.golden
@@ -1,4 +1,3 @@
 #[incorrect-context.kl:5.10-5.22]<(define x 5)>:
   Used in a position expecting an expression
   but is valid in a position expecting a top-level declaration or example
-ExitFailure 1

--- a/examples/non-examples/circular-1.golden
+++ b/examples/non-examples/circular-1.golden
@@ -1,0 +1,4 @@
+Circular imports while importing "examples/non-examples/circular-1.kl"
+  Context:
+    "examples/non-examples/circular-2.kl"
+    "examples/non-examples/circular-1.kl"

--- a/examples/non-examples/circular-2.golden
+++ b/examples/non-examples/circular-2.golden
@@ -1,0 +1,4 @@
+Circular imports while importing "examples/non-examples/circular-2.kl"
+  Context:
+    "examples/non-examples/circular-1.kl"
+    "examples/non-examples/circular-2.kl"

--- a/examples/non-examples/error.golden
+++ b/examples/non-examples/error.golden
@@ -1,0 +1,1 @@
+Error at phase p0: error.kl:3.18-3.34: "It went wrong."

--- a/examples/non-examples/import-phase.golden
+++ b/examples/non-examples/import-phase.golden
@@ -1,0 +1,1 @@
+Unknown: #[import-phase.kl:6.4-6.10]<define>

--- a/examples/non-examples/missing-import.golden
+++ b/examples/non-examples/missing-import.golden
@@ -1,0 +1,1 @@
+missing-import.kl:3.22-3.27: Not available at phase p0: magic

--- a/examples/non-examples/type-errors.golden
+++ b/examples/non-examples/type-errors.golden
@@ -1,0 +1,1 @@
+Type mismatch at type-errors.kl:3.36-3.37. Expected Syntax but got Integer

--- a/src/ModuleName.hs
+++ b/src/ModuleName.hs
@@ -7,12 +7,14 @@ module ModuleName (
   , moduleNameFromPath
   , moduleNameToPath
   , moduleNameText
+  , relativizeModuleName
   ) where
 
 import Data.Data (Data)
 import Data.Text (Text)
 import qualified Data.Text as T
 import System.Directory
+import System.FilePath
 
 import ShortShow
 
@@ -40,3 +42,10 @@ moduleNameText :: ModuleName -> Text
 moduleNameText (ModuleName f) = T.pack (show f)
 moduleNameText (KernelName _) = T.pack "kernel"
 
+-- | Given a path, relativize the @ModuleName@ with respect to the path.
+--
+-- > relativizeModuleName "a/b/c/klister" "a/b/c/klister/examples/do.kl" = "examples/do.kl"
+--
+relativizeModuleName :: FilePath -> ModuleName -> ModuleName
+relativizeModuleName l (ModuleName r) = ModuleName (makeRelative l r)
+relativizeModuleName _ k@KernelName{} = k

--- a/src/World.hs
+++ b/src/World.hs
@@ -5,7 +5,6 @@ module World where
 
 import Control.Lens
 import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Set (Set)
 
 import Core (MacroVar, Var)
@@ -23,29 +22,31 @@ data World a = World
   { _worldEnvironments :: !(Map Phase (Env Var a))
   , _worldTypeContexts :: !(TypeContext Var SchemePtr)
   , _worldTransformerEnvironments :: !(Map Phase (Env MacroVar a))
-  , _worldModules :: !(Map ModuleName CompleteModule)
-  , _worldVisited :: !(Map ModuleName (Set Phase))
-  , _worldExports :: !(Map ModuleName Exports)
-  , _worldEvaluated :: !(Map ModuleName [EvalResult])
-  , _worldDatatypes :: !(Map Phase (Map Datatype DatatypeInfo))
+  , _worldModules      :: !(Map ModuleName CompleteModule)
+  , _worldVisited      :: !(Map ModuleName (Set Phase))
+  , _worldExports      :: !(Map ModuleName Exports)
+  , _worldEvaluated    :: !(Map ModuleName [EvalResult])
+  , _worldDatatypes    :: !(Map Phase (Map Datatype DatatypeInfo))
   , _worldConstructors :: !(Map Phase (Map Constructor (ConstructorInfo Ty)))
+  , _worldLocation     :: FilePath
   }
 makeLenses ''World
 
 phaseEnv :: Phase -> World a -> Env Var a
 phaseEnv p = maybe Env.empty id . view (worldEnvironments . at p)
 
-initialWorld :: World a
-initialWorld =
-  World { _worldEnvironments = Map.empty
+initialWorld :: FilePath -> World a
+initialWorld fp =
+  World { _worldEnvironments = mempty
         , _worldTypeContexts = mempty
-        , _worldTransformerEnvironments = Map.empty
-        , _worldModules = Map.empty
-        , _worldVisited = Map.empty
-        , _worldExports = Map.empty
-        , _worldEvaluated = Map.empty
-        , _worldDatatypes = Map.empty
-        , _worldConstructors = Map.empty
+        , _worldTransformerEnvironments = mempty
+        , _worldModules      = mempty
+        , _worldVisited      = mempty
+        , _worldExports      = mempty
+        , _worldEvaluated    = mempty
+        , _worldDatatypes    = mempty
+        , _worldConstructors = mempty
+        , _worldLocation     = fp
         }
 
 addExpandedModule :: CompleteModule -> World a -> World a

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -14,6 +14,7 @@ import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import Data.Set (Set)
 import System.IO (stdout)
+import System.Directory
 import qualified Data.Text as T
 
 import Test.Tasty
@@ -465,7 +466,7 @@ testExpander input spec = do
   case readExpr "<test suite>" input of
     Left err -> assertFailure . T.unpack $ err
     Right expr -> do
-      ctx <- mkInitContext (KernelName kernelName)
+      ctx <- getCurrentDirectory >>= mkInitContext (KernelName kernelName)
       c <- execExpand ctx $ completely $ do
              initializeKernel stdout
              initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
@@ -485,7 +486,7 @@ testExpansionFails input okp =
   case readExpr "<test suite>" input of
     Left err -> assertFailure . T.unpack $ err
     Right expr -> do
-      ctx <- mkInitContext (KernelName kernelName)
+      ctx <- getCurrentDirectory >>= mkInitContext (KernelName kernelName)
       c <- execExpand ctx $ completely $ do
              initializeKernel stdout
              initializeLanguage (Stx ScopeSet.empty testLoc (KernelName kernelName))
@@ -508,7 +509,7 @@ testExpansionFails input okp =
 testFile :: FilePath -> (Module [] CompleteDecl -> [Value] -> Assertion) -> Assertion
 testFile f p = do
   mn <- moduleNameFromPath f
-  ctx <- mkInitContext mn
+  ctx <- getCurrentDirectory >>= mkInitContext mn
   void $ execExpand ctx (initializeKernel stdout)
   (execExpand ctx $ do
     visit mn >> view expanderWorld <$> getState) >>=
@@ -530,7 +531,7 @@ testFile f p = do
 testFileError :: FilePath -> (ExpansionErr -> Bool) -> Assertion
 testFileError f p = do
   mn <- moduleNameFromPath f
-  ctx <- mkInitContext mn
+  ctx <- getCurrentDirectory >>= mkInitContext mn
   void $ execExpand ctx (initializeKernel stdout)
   (execExpand ctx $ do
     visit mn >> view expanderWorld <$> getState) >>=


### PR DESCRIPTION
Closes out #42. This MR also:

- adds a `cabal.project` file, although a minimal one at that.