### PR TITLE
First pass performance engineering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,27 @@ jobs:
       matrix:
         include:
             # latest GHC, default OS
+          - cabal: "3.8"
+            ghc: "9.6"
+            os: ubuntu-latest
+
+            # non-latest GHC, default OS
+          - cabal: "3.8"
+            ghc: "9.4"
+            os: ubuntu-latest
+
+            # non-latest GHC, default OS
           - cabal: "3.6"
             ghc: "9.2.5"
             os: ubuntu-latest
 
-            # non-latest GHC, default OS
-          - cabal: "3.4"
-            ghc: "9.0.1"
-            os: ubuntu-latest
           - cabal: "3.2"
-            ghc: "8.10.2"
+            ghc: "8.10.7"
             os: ubuntu-latest
 
             # latest GHC, non-default OS
-          - cabal: "3.2"
-            ghc: "9.0.1"
+          - cabal: "3.8"
+            ghc: "9.6"
             os: macOS-latest
 
     steps:
@@ -79,18 +85,18 @@ jobs:
       # only test stack with one OS and one GHC version; if it works with
       # cabal, it probably also works with stack.
       matrix:
-        stack: ["2.3.1"]
-        ghc: ["8.10.2"]
+        ghc: ['9.2.8']
 
     steps:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v2
       name: Setup Haskell Stack
       with:
+        enable-stack: true
         ghc-version: ${{ matrix.ghc }}
-        stack-version: ${{ matrix.stack }}
+        stack-version: 'latest'
 
     - uses: actions/cache@v1
       name: Cache ~/.stack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,6 @@ jobs:
           - cabal: "3.2"
             ghc: "8.10.2"
             os: ubuntu-latest
-          - cabal: "3.2"
-            ghc: "8.8.4"
-            os: ubuntu-latest
-          - cabal: "3.2"
-            ghc: "8.6.5"
-            os: ubuntu-latest
 
             # latest GHC, non-default OS
           - cabal: "3.2"
@@ -74,6 +68,10 @@ jobs:
       run: |
         cabal test all
 
+    - name: TestDebug
+      run: |
+        cabal test all --ghc-options='-debug'
+
   stack:
     name: stack / ghc ${{ matrix.ghc }}
     runs-on: ubuntu-latest
@@ -82,7 +80,7 @@ jobs:
       # cabal, it probably also works with stack.
       matrix:
         stack: ["2.3.1"]
-        ghc: ["8.6.5"]
+        ghc: ["8.10.2"]
 
     steps:
     - uses: actions/checkout@v2

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,4 @@ packages:
     ./
 
 tests: True
+profiling: False

--- a/klister.cabal
+++ b/klister.cabal
@@ -22,11 +22,18 @@ source-repository head
   type: git
   location: https://github.com/gelisam/klister
 
+Flag KDebug
+    Description: Enable debug support for klister interpreter
+    Manual: True
+    Default: False
+
 common deps
   build-depends:
     base                 >= 4.12.0 && < 4.17,
     bifunctors           >= 5.5.5 && < 5.6,
     containers           >= 0.6 && < 0.7,
+    unordered-containers >= 0.2.15 && < 3,
+    hashable,
     directory            >= 1.3.3 && < 1.4,
     exceptions,
     extra                >= 1.6.18 && < 1.8,
@@ -38,8 +45,13 @@ common deps
     text                 ^>= 1.2,
     transformers         ^>= 0.5
 
+common flags
+  if flag(KDebug)
+    CPP-Options: -DKDEBUG
+
 library
   import: deps
+        , flags
   exposed-modules:
       Alpha
       Binding
@@ -75,11 +87,15 @@ library
       SplitCore
       SplitType
       Syntax
+      Syntax.Syntax
       Syntax.Lexical
       Syntax.SrcLoc
       Type
       Type.Context
       Unique
+      Util.Key
+      Util.Store
+      Util.Set
       Value
       World
   other-modules:
@@ -104,10 +120,12 @@ executable klister
 
 test-suite klister-tests
   import: deps
+        , flags
   type: exitcode-stdio-1.0
   main-is: Test.hs
   other-modules:
       Golden
+      MiniTests
       Paths_klister
   hs-source-dirs:
       tests

--- a/klister.cabal
+++ b/klister.cabal
@@ -29,8 +29,8 @@ Flag KDebug
 
 common deps
   build-depends:
-    base                 >= 4.12.0 && < 4.17,
-    bifunctors           >= 5.5.5 && < 5.6,
+    base                 >= 4.14.0 && < 5,
+    bifunctors           >= 5.5.5 && < 5.7,
     containers           >= 0.6 && < 0.7,
     unordered-containers >= 0.2.15 && < 3,
     hashable,
@@ -38,12 +38,12 @@ common deps
     exceptions,
     extra                >= 1.6.18 && < 1.8,
     filepath             >= 1.4.2 && < 1.5,
-    lens                 >= 4.17.1 && < 5.2,
+    lens                 >= 4.17.1 && < 5.3,
     megaparsec           >= 7.0.5 && < 9.3,
-    mtl                  >= 2.2.2 && < 2.3,
+    mtl                  >= 2.2.2 && < 2.4,
     prettyprinter        >= 1.2 && < 1.8,
-    text                 ^>= 1.2,
-    transformers         ^>= 0.5
+    text                 >= 1.2,
+    transformers         ^>= 0.6
 
 common flags
   if flag(KDebug)
@@ -131,12 +131,12 @@ test-suite klister-tests
       tests
   ghc-options: -Wall
   build-depends:
-    call-stack ^>= 0.1,
-    hedgehog >= 1.0 && < 1.4,
+    call-stack ^>= 0.4.0,
+    hedgehog >= 1.2 && < 1.4,
     klister,
     silently ^>= 1.2,
-    tasty ^>= 1.2,
+    tasty ^>= 1.4,
     tasty-golden ^>= 2.3,
-    tasty-hedgehog >= 1.0 && < 1.5,
+    tasty-hedgehog >= 1.4 && < 1.5,
     tasty-hunit ^>= 0.10
   default-language: Haskell2010

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -12,7 +12,7 @@ import Control.Monad.Reader
 
 import Data.Foldable (for_)
 import Data.IORef
-import qualified Data.Map as Map
+import qualified Data.HashMap.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 

--- a/repl/Main.hs
+++ b/repl/Main.hs
@@ -6,7 +6,7 @@ module Main where
 
 import Control.Exception
 import Control.Lens hiding (argument)
-import Control.Monad (forever)
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
 

--- a/src/Alpha.hs
+++ b/src/Alpha.hs
@@ -4,8 +4,8 @@ module Alpha where
 
 import Control.Applicative
 import Control.Lens
+import Control.Monad
 import Control.Monad.State
-import Control.Monad.Fail
 import Data.IntMap.Strict (IntMap)
 import Data.Maybe
 import Data.Text

--- a/src/Binding.hs
+++ b/src/Binding.hs
@@ -1,14 +1,18 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Binding where
 
 import Control.Lens
 import Data.Data (Data)
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.Hashable
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
 import ScopeSet
 import Data.Text (Text)
+import Data.Sequence (Seq)
 
 import Binding.Info
 import Phase
@@ -16,8 +20,17 @@ import ShortShow
 import Syntax.SrcLoc
 import Unique
 
+import Util.Key
+
 newtype Binding = Binding Unique
-  deriving (Data, Eq, Ord)
+  deriving newtype (Eq, Ord, Hashable)
+  deriving stock Data
+
+instance HasKey Binding where
+  getKey (Binding u) = getKey u
+  fromKey i = Binding $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
 
 instance Show Binding where
   show (Binding b) = "(Binding " ++ show (hashUnique b) ++ ")"
@@ -25,21 +38,21 @@ instance Show Binding where
 instance ShortShow Binding where
   shortShow (Binding b) = "b" ++ show (hashUnique b)
 
-newtype BindingTable = BindingTable { _bindings :: Map Text [(ScopeSet, Binding, BindingInfo SrcLoc)] }
+newtype BindingTable = BindingTable { _bindings :: HashMap Text (Seq (ScopeSet, Binding, BindingInfo SrcLoc)) }
   deriving (Data, Show)
 makeLenses ''BindingTable
 
 instance Semigroup BindingTable where
-  b1 <> b2 = BindingTable $ Map.unionWith (<>) (view bindings b1) (view bindings b2)
+  b1 <> b2 = BindingTable $ HM.unionWith (<>) (view bindings b1) (view bindings b2)
 
 instance Monoid BindingTable where
-  mempty = BindingTable Map.empty
+  mempty = BindingTable HM.empty
 
 instance Phased BindingTable where
-  shift i = over bindings (Map.map (map (over _1 (shift i))))
+  shift i = over bindings (HM.map (fmap (over _1 (shift i))))
 
 type instance Index BindingTable = Text
-type instance IxValue BindingTable = [(ScopeSet, Binding, BindingInfo SrcLoc)]
+type instance IxValue BindingTable = Seq (ScopeSet, Binding, BindingInfo SrcLoc)
 
 instance Ixed BindingTable where
   ix x f (BindingTable bs) = BindingTable <$> ix x f bs

--- a/src/Control/Lens/IORef.hs
+++ b/src/Control/Lens/IORef.hs
@@ -26,7 +26,7 @@ overIORef :: (MonadIO m, MonadReader r m)
           -> m ()
 overIORef refGetter leafSetter f = do
   ref <- view refGetter
-  liftIO $ modifyIORef ref (over leafSetter f)
+  liftIO $ modifyIORef' ref (over leafSetter f)
 
 setIORef :: (MonadIO m, MonadReader r m)
          => Getting (IORef s) r (IORef s)  -- ^ Getter r (IORef s)
@@ -35,4 +35,4 @@ setIORef :: (MonadIO m, MonadReader r m)
          -> m ()
 setIORef refGetter leafSetter a = do
   ref <- view refGetter
-  liftIO $ modifyIORef ref (set leafSetter a)
+  liftIO $ modifyIORef' ref (set leafSetter a)

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -9,9 +9,8 @@ representing fully-expanded expressions.
 
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
@@ -38,6 +37,7 @@ import Syntax.SrcLoc
 import Type
 import Unique
 
+import Util.Key
 
 data SyntaxError a = SyntaxError
   { _syntaxErrorLocations :: [a]
@@ -47,13 +47,27 @@ data SyntaxError a = SyntaxError
 makeLenses ''SyntaxError
 
 newtype Var = Var Unique
-  deriving (AlphaEq, Data, Eq, Ord)
+  deriving newtype (AlphaEq, Eq, Ord)
+  deriving stock Data
+
+instance HasKey Var where
+  getKey (Var u) = getKey u
+  fromKey i = Var $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
 
 instance Show Var where
   show (Var i) = "(Var " ++ show (hashUnique i) ++ ")"
 
 newtype MacroVar = MacroVar Unique
-  deriving (AlphaEq, Data, Eq, Ord)
+  deriving newtype (AlphaEq, Eq, Ord)
+  deriving stock Data
+
+instance HasKey MacroVar where
+  getKey (MacroVar u) = getKey u
+  fromKey i = MacroVar $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
 
 instance Show MacroVar where
   show (MacroVar i) = "(MacroVar " ++ show (hashUnique i) ++ ")"

--- a/src/Datatype.hs
+++ b/src/Datatype.hs
@@ -1,20 +1,25 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Datatype where
 
 import Control.Lens
 import Data.Data (Data)
 import Data.String
 import Data.Text (Text)
+import Data.Hashable
 
 import Alpha
 import Kind
 import ModuleName
 import ShortShow
+import GHC.Generics (Generic)
 
 newtype DatatypeName = DatatypeName { _datatypeNameText :: Text }
-  deriving (Data, Eq, IsString, Ord, Show)
+  deriving newtype (Eq, IsString, Ord, Show, Hashable)
+  deriving stock Data
 makeLenses ''DatatypeName
 
 data Datatype
@@ -22,11 +27,14 @@ data Datatype
     { _datatypeModule :: !ModuleName -- ^ The module that defines the datatype
     , _datatypeName :: !DatatypeName -- ^ The unique name for the datatype at this module and phase
     }
-  deriving (Data, Eq, Ord, Show)
+  deriving stock (Data, Eq, Ord, Show, Generic)
 makeLenses ''Datatype
 
+instance Hashable Datatype
+
 newtype ConstructorName = ConstructorName  { _constructorNameText :: Text }
-  deriving (Data, Eq, IsString, Ord, Show)
+  deriving newtype (Eq, IsString, Ord, Show, Hashable)
+  deriving stock   Data
 makeLenses ''ConstructorName
 
 data Constructor
@@ -34,9 +42,10 @@ data Constructor
     { _constructorModule :: !ModuleName -- ^ The module that defines the constructor
     , _constructorName :: !ConstructorName -- ^ The unique name for the constructor at this module and phase
     }
-  deriving (Data, Eq, Ord, Show)
+  deriving (Data, Eq, Ord, Show, Generic)
 makeLenses ''Constructor
 
+instance Hashable Constructor
 instance ShortShow Constructor where
   shortShow = show
 

--- a/src/Env.hs
+++ b/src/Env.hs
@@ -1,53 +1,65 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE DerivingStrategies #-}
+
 module Env (Env, empty, insert, singleton, lookup, lookupIdent, lookupVal, toList, fromList, named) where
 
 import Prelude hiding (lookup)
 
 import Control.Lens
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IM
 import Data.Text (Text)
 
 import Syntax (Ident, Stx(..))
 
-newtype Env v a = Env (Map v (Ident, a))
-  deriving (Eq, Functor, Monoid, Semigroup, Show)
+import Util.Key
+
+-- | An environment maps variables of type 'v' to values of type 'a'.
+--
+-- More specifically, 'Env' is intended to be used for variables in the core
+-- language, such as 'Var' and 'MacroVar', which are represented as unique
+-- integers in order to avoid accidental capture. To make error message more
+-- readable, 'Env' stores the original 'Ident' in addition to the value.
+newtype Env v a = Env (IntMap (Ident, a))
+  deriving newtype (Eq, Monoid, Semigroup, Show)
+  deriving stock Functor
 
 empty :: Env v a
-empty = Env (Map.empty)
+empty = Env mempty
 
-toList :: Env v a -> [(v, Ident, a)]
-toList (Env env) = [(x, n, v) | (x, (n, v)) <- Map.toList env]
+toList :: HasKey v => Env v a -> [(v, Ident, a)]
+toList (Env env) = [(fromKey x, n, v) | (x, (n, v)) <- IM.toList env]
 
-fromList :: Ord v => [(v, Ident, a)] -> Env v a
-fromList vars = Env (Map.fromList [(x, (n, v)) | (x, n, v) <- vars])
+fromList :: HasKey v => [(v, Ident, a)] -> Env v a
+fromList vars = Env (IM.fromList [(getKey x, (n, v)) | (x, n, v) <- vars])
 
-singleton :: v -> Ident -> a -> Env v a
-singleton x n v = Env (Map.singleton x (n, v))
+singleton :: HasKey v => v -> Ident -> a -> Env v a
+singleton x n v = Env (IM.singleton (getKey x) (n, v))
 
-insert :: Ord v => v -> Ident -> a -> Env v a -> Env v a
-insert x n v (Env env) = Env (Map.insert x (n, v) env)
+insert :: HasKey v => v -> Ident -> a -> Env v a -> Env v a
+insert x n v (Env env) = Env (IM.insert (getKey x) (n, v) env)
 
-lookup :: Ord v => v -> Env v a -> Maybe (Ident, a)
-lookup x (Env env) = Map.lookup x env
+lookup :: HasKey v => v -> Env v a -> Maybe (Ident, a)
+lookup x (Env env) = IM.lookup (getKey x) env
 
-lookupVal :: Ord v => v -> Env v a -> Maybe a
+lookupVal :: HasKey v => v -> Env v a -> Maybe a
 lookupVal x env = snd <$> lookup x env
 
-lookupIdent :: Ord v => v -> Env v a -> Maybe Ident
+lookupIdent :: HasKey v => v -> Env v a -> Maybe Ident
 lookupIdent x env = fst <$> lookup x env
 
-named :: Text -> Env v a -> [(v, a)]
-named n (Env xs) = [(x, a) | (x, (Stx _ _ n', a)) <- Map.toList xs, n == n']
+named :: HasKey v => Text -> Env v a -> [(v, a)]
+named n (Env xs) = [(fromKey x, a) | (x, (Stx _ _ n', a)) <- IM.toList xs, n == n']
 
 type instance Index (Env v a) = v
 type instance IxValue (Env v a) = (Ident, a)
 
-instance Ord v => Ixed (Env v a) where
-  ix var f (Env env) = Env <$> ix var f env
+instance HasKey v => Ixed (Env v a) where
+  ix var f (Env env) = Env <$> ix (getKey var) f env
+  {-# INLINE ix #-}
 
-instance Ord v => At (Env v a) where
-  at x f (Env env) = Env <$> at x f env
+instance HasKey v => At (Env v a) where
+  at x f (Env env) = Env <$> at (getKey x) f env
+  {-# INLINE at #-}

--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -40,6 +40,7 @@ module Expander (
 
 import Control.Applicative
 import Control.Lens hiding (List, children)
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State.Strict
@@ -48,7 +49,6 @@ import Data.Function (on)
 import Data.List (nub)
 import qualified Data.HashMap.Strict as HM
 import Data.Maybe
-import Data.Ord
 import Data.Sequence (Seq(..))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)

--- a/src/Expander/DeclScope.hs
+++ b/src/Expander/DeclScope.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Expander.DeclScope where
 
 import Unique
+import Util.Key
 
 -- | A 'DeclOutputScopesPtr' gets filled with a 'ScopeSet' consisting of all the
 -- scopes introduced by a declaration or a declaration group, so that later code
@@ -9,7 +12,7 @@ import Unique
 -- Note that 'DeclOutputScopesPtr' gets filled once we know which _names_ get
 -- bound, the values to which they are bound may not be fully-expanded yet.
 newtype DeclOutputScopesPtr = DeclOutputScopesPtr Unique
-  deriving (Eq, Ord)
+  deriving newtype (Eq, Ord, HasKey)
 
 instance Show DeclOutputScopesPtr where
   show (DeclOutputScopesPtr u) = "(DeclOutputScopesPtr " ++ show (hashUnique u) ++ ")"

--- a/src/Expander/Error.hs
+++ b/src/Expander/Error.hs
@@ -13,7 +13,9 @@ module Expander.Error
 import Control.Lens
 import Numeric.Natural
 import Data.Text (Text)
+import Data.Sequence (Seq)
 import qualified Data.Text as T
+import Data.Foldable
 
 import Core
 import Datatype
@@ -31,7 +33,7 @@ import Type
 import Value
 
 data ExpansionErr
-  = Ambiguous Phase Ident [ScopeSet]
+  = Ambiguous Phase Ident (Seq ScopeSet)
   | Unknown (Stx Text)
   | NoProgress [ExpanderTask]
   | NotIdentifier Syntax
@@ -113,7 +115,7 @@ instance Pretty VarInfo ExpansionErr where
       text "Scope set of the identifier:" <> line <>
         viaShow (_stxScopeSet x) <> line <>
       text "Scope sets of the candidates:" <> line <>
-        vsep [viaShow c | c <- candidates]
+        vsep [viaShow c | c <- toList candidates]
   pp env (Unknown x) = text "Unknown:" <+> pp env x
   pp env (NoProgress tasks) =
     hang 4 $

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -152,6 +152,7 @@ module Expander.Monad
 import Control.Applicative
 import Control.Arrow
 import Control.Lens
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Foldable

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -1,9 +1,15 @@
-{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE BlockArguments     #-}
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+{-# LANGUAGE BangPatterns #-}
+
 module Expander.Monad
   ( module Expander.Error
   , module Expander.DeclScope
@@ -150,8 +156,9 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Data.Foldable
 import Data.IORef
-import Data.Map (Map)
-import qualified Data.Map as Map
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
+import Data.Sequence (Seq(..))
 import Data.Maybe
 import Data.Monoid
 import Data.Text (Text)
@@ -189,6 +196,10 @@ import Unique
 import Value
 import World
 
+import Util.Store (Store)
+import qualified Util.Store as S
+import Util.Key
+
 newtype Expand a = Expand
   { runExpand :: ReaderT ExpanderContext (ExceptT ExpansionErr IO) a
   }
@@ -199,7 +210,7 @@ execExpand ctx act = runExceptT $ runReaderT (runExpand act) ctx
 
 
 newtype TaskID = TaskID Unique
-  deriving (Eq, Ord)
+  deriving newtype (Eq, Ord, HasKey)
 
 instance Show TaskID where
   show (TaskID u) = "(TaskID " ++ show (hashUnique u) ++ ")"
@@ -212,7 +223,7 @@ newDeclOutputScopesPtr = DeclOutputScopesPtr <$> liftIO newUnique
 
 
 
-newtype ExpansionEnv = ExpansionEnv (Map.Map Binding EValue)
+newtype ExpansionEnv = ExpansionEnv (Store Binding EValue)
   deriving (Semigroup, Monoid)
 
 data EValue
@@ -242,7 +253,7 @@ data ExpanderContext = ExpanderContext
 data ExpanderLocal = ExpanderLocal
   { _expanderModuleName :: !ModuleName
   , _expanderPhase :: !Phase
-  , _expanderBindingLevels :: !(Map Phase BindingLevel)
+  , _expanderBindingLevels :: !(Store Phase BindingLevel)
   , _expanderVarTypes :: TypeContext Var SchemePtr
   , _expanderKlisterPath :: !KlisterPath
   , _expanderImportStack :: [ModuleName]
@@ -251,93 +262,93 @@ data ExpanderLocal = ExpanderLocal
 mkInitContext :: ModuleName -> FilePath -> IO ExpanderContext
 mkInitContext mn here = do
   kPath <- getKlisterPath
-  st <- newIORef $! initExpanderState here
-  return $ ExpanderContext { _expanderState = st
-                           , _expanderLocal = ExpanderLocal
-                             { _expanderModuleName = mn
-                             , _expanderPhase = runtime
-                             , _expanderBindingLevels = Map.empty
-                             , _expanderVarTypes = mempty
-                             , _expanderKlisterPath = kPath
-                             , _expanderImportStack = []
+  !st <- newIORef $! initExpanderState here
+  return $! ExpanderContext { _expanderState = st
+                            , _expanderLocal = ExpanderLocal
+                              { _expanderModuleName  = mn
+                              , _expanderPhase       = runtime
+                              , _expanderBindingLevels = mempty
+                              , _expanderVarTypes    = mempty
+                              , _expanderKlisterPath = kPath
+                              , _expanderImportStack = []
                              }
                            }
 
 data ExpanderState = ExpanderState
-  { _expanderWorld :: !(World Value)
-  , _expanderNextScopeNum :: !Int
+  { _expanderWorld              :: !(World Value)
+  , _expanderNextScopeNum       :: !Int
   , _expanderGlobalBindingTable :: !BindingTable
-  , _expanderExpansionEnv :: !ExpansionEnv
-  , _expanderTasks :: [(TaskID, ExpanderLocal, ExpanderTask)]
-  , _expanderOriginLocations :: !(Map.Map SplitCorePtr SrcLoc)
-  , _expanderCompletedCore :: !(Map.Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr))
-  , _expanderCompletedPatterns :: !(Map.Map PatternPtr (ConstructorPatternF PatternPtr))
-  , _expanderCompletedTypePatterns :: !(Map.Map TypePatternPtr TypePattern)
-  , _expanderPatternBinders :: !(Map.Map PatternPtr (Either [PatternPtr] (Scope, Ident, Var, SchemePtr)))
-  , _expanderTypePatternBinders :: !(Map.Map TypePatternPtr [(Scope, Ident, Var, SchemePtr)])
-  , _expanderCompletedTypes :: !(Map.Map SplitTypePtr (TyF SplitTypePtr))
-  , _expanderCompletedDeclTrees :: !(Map.Map DeclTreePtr (DeclTreeF DeclPtr DeclTreePtr))
-  , _expanderCompletedDecls :: !(Map.Map DeclPtr (Decl SplitTypePtr SchemePtr DeclTreePtr SplitCorePtr))
-  , _expanderModuleTop :: !(Maybe DeclTreePtr)
-  , _expanderModuleImports :: !Imports
-  , _expanderModuleExports :: !Exports
-  , _expanderPhaseRoots :: !(Map Phase Scope)
-  , _expanderModuleRoots :: !(Map ModuleName Scope)
-  , _expanderKernelBindings :: !BindingTable
-  , _expanderKernelExports :: !Exports
-  , _expanderKernelDatatypes :: !(Map Datatype DatatypeInfo)
-  , _expanderKernelConstructors :: !(Map Constructor (ConstructorInfo Ty))
-  , _expanderKernelValues :: !(Env Var (SchemePtr, Value))
-  , _expanderDeclOutputScopes :: !(Map DeclOutputScopesPtr ScopeSet)
-  , _expanderCurrentEnvs :: !(Map Phase (Env Var Value))
-  , _expanderCurrentTransformerEnvs :: !(Map Phase (Env MacroVar Value))
-  , _expanderCurrentDatatypes :: !(Map Phase (Map Datatype DatatypeInfo))
-  , _expanderCurrentConstructors :: !(Map Phase (Map Constructor (ConstructorInfo Ty)))
+  , _expanderExpansionEnv       :: !ExpansionEnv
+  , _expanderTasks              :: [(TaskID, ExpanderLocal, ExpanderTask)]
+  , _expanderOriginLocations    :: !(Store SplitCorePtr SrcLoc)
+  , _expanderCompletedCore      :: !(Store SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr))
+  , _expanderCompletedPatterns  :: !(Store PatternPtr (ConstructorPatternF PatternPtr))
+  , _expanderCompletedTypePatterns :: !(Store TypePatternPtr TypePattern)
+  , _expanderPatternBinders     :: !(Store PatternPtr (Either [PatternPtr] (Scope, Ident, Var, SchemePtr)))
+  , _expanderTypePatternBinders :: !(Store TypePatternPtr [(Scope, Ident, Var, SchemePtr)])
+  , _expanderCompletedTypes     :: !(Store SplitTypePtr (TyF SplitTypePtr))
+  , _expanderCompletedDeclTrees :: !(Store DeclTreePtr (DeclTreeF DeclPtr DeclTreePtr))
+  , _expanderCompletedDecls     :: !(Store DeclPtr (Decl SplitTypePtr SchemePtr DeclTreePtr SplitCorePtr))
+  , _expanderModuleTop          :: !(Maybe DeclTreePtr)
+  , _expanderModuleImports      :: !Imports
+  , _expanderModuleExports      :: !Exports
+  , _expanderPhaseRoots         :: !(Store Phase Scope)
+  , _expanderModuleRoots        :: !(HashMap ModuleName Scope)
+  , _expanderKernelBindings     :: !BindingTable
+  , _expanderKernelExports      :: !Exports
+  , _expanderKernelDatatypes    :: !(HashMap Datatype DatatypeInfo)
+  , _expanderKernelConstructors :: !(HashMap Constructor (ConstructorInfo Ty))
+  , _expanderKernelValues       :: !(Env Var (SchemePtr, Value))
+  , _expanderDeclOutputScopes   :: !(Store DeclOutputScopesPtr ScopeSet)
+  , _expanderCurrentEnvs        :: !(Store Phase (Env Var Value))
+  , _expanderCurrentTransformerEnvs :: !(Store Phase (Env MacroVar Value))
+  , _expanderCurrentDatatypes   :: !(Store Phase (HashMap Datatype DatatypeInfo))
+  , _expanderCurrentConstructors :: !(Store Phase (HashMap Constructor (ConstructorInfo Ty)))
   , _expanderCurrentBindingTable :: !BindingTable
-  , _expanderExpressionTypes :: !(Map SplitCorePtr Ty)
-  , _expanderCompletedSchemes :: !(Map SchemePtr (Scheme Ty))
-  , _expanderTypeStore :: !(TypeStore Ty)
-  , _expanderKindStore :: !KindStore
-  , _expanderDefTypes :: !(TypeContext Var SchemePtr) -- ^ Module-level definitions
+  , _expanderExpressionTypes    :: !(Store SplitCorePtr Ty)
+  , _expanderCompletedSchemes   :: !(Store SchemePtr (Scheme Ty))
+  , _expanderTypeStore          :: !(TypeStore Ty)
+  , _expanderKindStore          :: !KindStore
+  , _expanderDefTypes           :: !(TypeContext Var SchemePtr) -- ^ Module-level definitions
   }
 
 initExpanderState :: FilePath -> ExpanderState
 initExpanderState here = ExpanderState
-  { _expanderWorld = initialWorld here
+  { _expanderWorld        = initialWorld here
   , _expanderNextScopeNum = 0
   , _expanderGlobalBindingTable = mempty
-  , _expanderExpansionEnv = mempty
-  , _expanderTasks = []
-  , _expanderOriginLocations = Map.empty
-  , _expanderCompletedCore = Map.empty
-  , _expanderCompletedPatterns = Map.empty
-  , _expanderCompletedTypePatterns = Map.empty
-  , _expanderPatternBinders = Map.empty
-  , _expanderTypePatternBinders = Map.empty
-  , _expanderCompletedTypes = Map.empty
-  , _expanderCompletedDeclTrees = Map.empty
-  , _expanderCompletedDecls = Map.empty
-  , _expanderModuleTop = Nothing
-  , _expanderModuleImports = noImports
-  , _expanderModuleExports = noExports
-  , _expanderPhaseRoots = Map.empty
-  , _expanderModuleRoots = Map.empty
-  , _expanderKernelBindings = mempty
-  , _expanderKernelExports = noExports
-  , _expanderKernelDatatypes = mempty
+  , _expanderExpansionEnv       = mempty
+  , _expanderTasks              = mempty
+  , _expanderOriginLocations    = mempty
+  , _expanderCompletedCore      = mempty
+  , _expanderCompletedPatterns  = mempty
+  , _expanderCompletedTypePatterns = mempty
+  , _expanderPatternBinders     = mempty
+  , _expanderTypePatternBinders = mempty
+  , _expanderCompletedTypes     = mempty
+  , _expanderCompletedDeclTrees = mempty
+  , _expanderCompletedDecls     = mempty
+  , _expanderModuleTop          = Nothing
+  , _expanderModuleImports      = noImports
+  , _expanderModuleExports      = noExports
+  , _expanderPhaseRoots         = mempty
+  , _expanderModuleRoots        = mempty
+  , _expanderKernelBindings     = mempty
+  , _expanderKernelExports      = noExports
+  , _expanderKernelDatatypes    = mempty
   , _expanderKernelConstructors = mempty
-  , _expanderKernelValues = mempty
-  , _expanderDeclOutputScopes = Map.empty
-  , _expanderCurrentEnvs = Map.empty
-  , _expanderCurrentTransformerEnvs = Map.empty
-  , _expanderCurrentDatatypes = Map.empty
-  , _expanderCurrentConstructors = Map.empty
+  , _expanderKernelValues       = mempty
+  , _expanderDeclOutputScopes   = mempty
+  , _expanderCurrentEnvs        = mempty
+  , _expanderCurrentTransformerEnvs = mempty
+  , _expanderCurrentDatatypes    = mempty
+  , _expanderCurrentConstructors = mempty
   , _expanderCurrentBindingTable = mempty
-  , _expanderExpressionTypes = Map.empty
-  , _expanderCompletedSchemes = Map.empty
-  , _expanderTypeStore = mempty
-  , _expanderKindStore = mempty
-  , _expanderDefTypes = mempty
+  , _expanderExpressionTypes     = mempty
+  , _expanderCompletedSchemes    = mempty
+  , _expanderTypeStore           = mempty
+  , _expanderKindStore           = mempty
+  , _expanderDefTypes            = mempty
   }
 
 makeLenses ''ExpanderContext
@@ -353,14 +364,24 @@ getState = view expanderState <$> expanderContext >>= liftIO . readIORef
 
 modifyState :: (ExpanderState -> ExpanderState) -> Expand ()
 modifyState f = do
-  st <- view expanderState <$> expanderContext
-  liftIO (modifyIORef st f)
+  !st <- view expanderState <$> expanderContext
+  liftIO (modifyIORef' st f)
 
+#ifndef KDEBUG
 freshScope :: Text -> Expand Scope
+{-# INLINE freshScope #-}
+freshScope _why = do
+  n <- view expanderNextScopeNum <$> getState
+  modifyState $ over expanderNextScopeNum (+ 1)
+  return (Scope n)
+#else
+freshScope :: Text -> Expand Scope
+{-# INLINE freshScope #-}
 freshScope why = do
   n <- view expanderNextScopeNum <$> getState
-  modifyState $ over expanderNextScopeNum $ (+ 1)
+  modifyState $ over expanderNextScopeNum (+ 1)
   return (Scope n why)
+#endif
 
 freshBinding :: Expand Binding
 freshBinding = Binding <$> liftIO newUnique
@@ -383,14 +404,12 @@ inEarlierPhase act =
   Expand $ local (over (expanderLocal . expanderPhase) prior) $ runExpand act
 
 moduleScope :: ModuleName -> Expand Scope
-moduleScope mn = do
-  sc <- moduleScope' mn
-  return sc
+moduleScope mn = moduleScope' mn
 
 moduleScope' :: ModuleName -> Expand Scope
 moduleScope' mn = do
   mods <- view expanderModuleRoots <$> getState
-  case Map.lookup mn mods of
+  case HM.lookup mn mods of
     Just sc -> return sc
     Nothing -> do
       sc <- freshScope $ T.pack $ "Module root for " ++ shortShow mn
@@ -402,7 +421,7 @@ phaseRoot :: Expand Scope
 phaseRoot = do
   roots <- view expanderPhaseRoots <$> getState
   p <- currentPhase
-  case Map.lookup p roots of
+  case S.lookup p roots of
     Just sc -> return sc
     Nothing -> do
       sc <- freshScope $ T.pack $ "Root for phase " ++ shortShow p
@@ -417,28 +436,28 @@ makePrisms ''ExpanderTask
 
 linkExpr :: SplitCorePtr -> CoreF TypePatternPtr PatternPtr SplitCorePtr -> Expand ()
 linkExpr dest layer =
-  modifyState $ over expanderCompletedCore (<> Map.singleton dest layer)
+  modifyState $ over expanderCompletedCore (<> S.singleton dest layer)
 
 linkPattern :: PatternPtr -> ConstructorPatternF PatternPtr -> Expand ()
 linkPattern dest pat =
-  modifyState $ over expanderCompletedPatterns (<> Map.singleton dest pat)
+  modifyState $ over expanderCompletedPatterns (<> S.singleton dest pat)
 
 linkTypePattern :: TypePatternPtr -> TypePattern -> [(Scope, Ident, Var, SchemePtr)] -> Expand ()
 linkTypePattern dest pat vars = do
   modifyState $ set (expanderTypePatternBinders . at dest) $ Just vars
-  modifyState $ over expanderCompletedTypePatterns (<> Map.singleton dest pat)
+  modifyState $ over expanderCompletedTypePatterns (<> S.singleton dest pat)
 
 linkDeclTree :: DeclTreePtr -> DeclTreeF DeclPtr DeclTreePtr -> Expand ()
 linkDeclTree dest declTreeF =
-  modifyState $ over expanderCompletedDeclTrees $ (<> Map.singleton dest declTreeF)
+  modifyState $ over expanderCompletedDeclTrees $ (<> S.singleton dest declTreeF)
 
 linkDecl :: DeclPtr -> Decl SplitTypePtr SchemePtr DeclTreePtr SplitCorePtr -> Expand ()
 linkDecl dest decl =
-  modifyState $ over expanderCompletedDecls $ (<> Map.singleton dest decl)
+  modifyState $ over expanderCompletedDecls $ (<> S.singleton dest decl)
 
 linkDeclOutputScopes :: DeclOutputScopesPtr -> ScopeSet -> Expand ()
 linkDeclOutputScopes dest scopeSet =
-  modifyState $ over expanderDeclOutputScopes $ (<> Map.singleton dest scopeSet)
+  modifyState $ over expanderDeclOutputScopes $ (<> S.singleton dest scopeSet)
 
 linkOneDecl :: DeclTreePtr -> Decl SplitTypePtr SchemePtr DeclTreePtr SplitCorePtr -> Expand ()
 linkOneDecl declTreeDest decl = do
@@ -448,16 +467,16 @@ linkOneDecl declTreeDest decl = do
 
 linkType :: SplitTypePtr -> TyF SplitTypePtr -> Expand ()
 linkType dest ty =
-  modifyState $ over expanderCompletedTypes (<> Map.singleton dest ty)
+  modifyState $ over expanderCompletedTypes (<> S.singleton dest ty)
 
 linkScheme :: SchemePtr -> Scheme Ty -> Expand ()
 linkScheme ptr sch =
-  modifyState $ over expanderCompletedSchemes (<> Map.singleton ptr sch)
+  modifyState $ over expanderCompletedSchemes (<> S.singleton ptr sch)
 
 linkStatus :: SplitCorePtr -> Expand (Maybe (CoreF TypePatternPtr PatternPtr SplitCorePtr))
 linkStatus slot = do
   complete <- view expanderCompletedCore <$> getState
-  return $ Map.lookup slot complete
+  return $ S.lookup slot complete
 
 linkedCore :: SplitCorePtr -> Expand (Maybe Core)
 linkedCore slot =
@@ -568,16 +587,16 @@ dependencies slot =
     Nothing -> pure [slot]
     Just c -> foldMap id <$> traverse dependencies c
 
-getDeclGroup :: DeclTreePtr -> Expand [CompleteDecl]
+getDeclGroup :: DeclTreePtr -> Expand (Seq CompleteDecl)
 getDeclGroup ptr =
   (view (expanderCompletedDeclTrees . at ptr) <$> getState) >>=
   \case
     Nothing -> throwError $ InternalError "Incomplete module after expansion"
-    Just DeclTreeLeaf -> pure []
+    Just DeclTreeLeaf -> pure mempty
     Just (DeclTreeAtom decl) ->
-      (:[]) <$> getDecl decl
+      pure <$> getDecl decl
     Just (DeclTreeBranch l r) ->
-      (++) <$> getDeclGroup l <*> getDeclGroup r
+      (<>) <$> getDeclGroup l <*> getDeclGroup r
 
 getDecl :: DeclPtr -> Expand CompleteDecl
 getDecl ptr =
@@ -720,7 +739,7 @@ freshDatatype (Stx _ _ hint) = do
     go ph mn n = do
       let attempt = hint <> maybe "" (T.pack . show) n
       let candidate = Datatype { _datatypeName = DatatypeName attempt, _datatypeModule = mn }
-      found <- view (expanderCurrentDatatypes . at ph . non Map.empty . at candidate) <$> getState
+      found <- view (expanderCurrentDatatypes . at ph . non HM.empty . at candidate) <$> getState
       case found of
         Nothing -> return candidate
         Just _ -> go ph mn (Just (maybe 0 (1+) n))
@@ -736,7 +755,7 @@ freshConstructor (Stx _ _ hint) = do
     go ph mn n = do
       let attempt = hint <> maybe "" (T.pack . show) n
       let candidate = Constructor { _constructorName = ConstructorName attempt, _constructorModule = mn }
-      found <- view (expanderCurrentConstructors . at ph . non Map.empty . at candidate) <$> getState
+      found <- view (expanderCurrentConstructors . at ph . non HM.empty . at candidate) <$> getState
       case found of
         Nothing -> return candidate
         Just _ -> go ph mn (Just (maybe 0 (1+) n))
@@ -744,8 +763,8 @@ freshConstructor (Stx _ _ hint) = do
 constructorInfo :: Constructor -> Expand (ConstructorInfo Ty)
 constructorInfo ctor = do
   p <- currentPhase
-  fromWorld <- view (expanderWorld . worldConstructors . at p . non Map.empty . at ctor) <$> getState
-  fromModule <- view (expanderCurrentConstructors . at p . non Map.empty . at ctor) <$> getState
+  fromWorld <- view (expanderWorld . worldConstructors . at p . non mempty . at ctor) <$> getState
+  fromModule <- view (expanderCurrentConstructors . at p . non mempty . at ctor) <$> getState
   case fromWorld <|> fromModule of
     Nothing ->
       throwError $ InternalError $ "Unknown constructor " ++ show ctor
@@ -754,8 +773,8 @@ constructorInfo ctor = do
 datatypeInfo :: Datatype -> Expand DatatypeInfo
 datatypeInfo datatype = do
   p <- currentPhase
-  fromWorld <- view (expanderWorld . worldDatatypes . at p . non Map.empty . at datatype) <$> getState
-  fromModule <- view (expanderCurrentDatatypes . at p . non Map.empty . at datatype) <$> getState
+  fromWorld <- view (expanderWorld . worldDatatypes . at p . non mempty . at datatype) <$> getState
+  fromModule <- view (expanderCurrentDatatypes . at p . non mempty . at datatype) <$> getState
   case fromWorld <|> fromModule of
     Nothing ->
       throwError $ InternalError $ "Unknown datatype " ++ show datatype
@@ -766,13 +785,13 @@ bind b v =
   modifyState $
   over expanderExpansionEnv $
   \(ExpansionEnv env) ->
-    ExpansionEnv $ Map.insert b v env
+    ExpansionEnv $ S.insert b v env
 
 -- | Add a binding to the current module's table
 addBinding :: Ident -> Binding -> BindingInfo SrcLoc -> Expand ()
 addBinding (Stx scs _ name) b info = do
   modifyState $ over (expanderCurrentBindingTable . at name) $
-    (Just . ((scs, b, info) :) . fromMaybe [])
+    (Just . ((scs, b, info) :<|) . fromMaybe mempty)
 
 addImportBinding :: Ident -> Binding -> Expand ()
 addImportBinding x@(Stx _ loc _) b =
@@ -859,9 +878,9 @@ currentTransformerEnv = do
 currentEnv :: Expand VEnv
 currentEnv = do
   phase <- currentPhase
-  globalEnv <-  maybe Env.empty id . view (expanderWorld . worldEnvironments . at phase) <$> getState
-  localEnv <- maybe Env.empty id . view (expanderCurrentEnvs . at phase) <$> getState
-  return (globalEnv <> localEnv)
+  globalEnv <- fromMaybe mempty . view (expanderWorld . worldEnvironments . at phase) <$> getState
+  localEnv  <- fromMaybe mempty . view (expanderCurrentEnvs . at phase) <$> getState
+  return $! globalEnv <> localEnv
 
 scheduleType :: Kind -> Syntax -> Expand SplitTypePtr
 scheduleType kind stx = do

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -64,7 +64,6 @@ module Expander.Primitives
 import Control.Lens hiding (List)
 import Control.Monad.IO.Class
 import Control.Monad.Except
-import qualified Data.Map as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Traversable
@@ -158,7 +157,7 @@ datatype dest outScopesDest stx = do
         }
   modifyState $
     set (expanderCurrentDatatypes .
-         at p . non Map.empty .
+         at p . non mempty .
          at d) $
     Just info
 

--- a/src/Expander/Primitives.hs
+++ b/src/Expander/Primitives.hs
@@ -63,6 +63,7 @@ module Expander.Primitives
 
 import Control.Lens hiding (List)
 import Control.Monad.IO.Class
+import Control.Monad
 import Control.Monad.Except
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Expander/Syntax.hs
+++ b/src/Expander/Syntax.hs
@@ -8,6 +8,7 @@
 module Expander.Syntax where
 
 import Control.Monad.Except
+import Control.Monad.IO.Class
 import Data.Functor.Identity (Identity(Identity))
 import Data.List (nub, sort)
 import Data.Text (Text)

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -10,6 +10,7 @@ module Expander.TC (
   ) where
 
 import Control.Lens hiding (indices)
+import Control.Monad
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Foldable

--- a/src/Expander/TC.hs
+++ b/src/Expander/TC.hs
@@ -13,8 +13,6 @@ import Control.Lens hiding (indices)
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Foldable
-import Data.Map (Map)
-import qualified Data.Map as Map
 import Numeric.Natural
 
 import Expander.Monad
@@ -26,6 +24,9 @@ import Syntax (Syntax, stxLoc)
 import Syntax.SrcLoc
 import Type
 import World
+
+import Util.Store (Store)
+import qualified Util.Store as St
 
 derefType :: MetaPtr -> Expand (TVar Ty)
 derefType ptr =
@@ -160,35 +161,35 @@ notFreeInCtx var = do
 generalizeType :: Ty -> Expand (Scheme Ty)
 generalizeType ty = do
   canGeneralize <- filterM notFreeInCtx =<< metas ty
-  (body, (_, _, argKinds)) <- flip runStateT (0, Map.empty, []) $ do
+  (body, (_, _, argKinds)) <- flip runStateT (0, mempty, []) $ do
     genTyVars canGeneralize ty
   pure $ Scheme argKinds body
 
   where
     genTyVars ::
       [MetaPtr] -> Ty ->
-      StateT (Natural, Map MetaPtr Natural, [Kind]) Expand Ty
+      StateT (Natural, Store MetaPtr Natural, [Kind]) Expand Ty
     genTyVars vars t = do
       (Ty t') <- lift $ normType t
       Ty <$> genVarsTyF vars t'
 
     genVarsTyF ::
       [MetaPtr] -> TyF Ty ->
-      StateT (Natural, Map MetaPtr Natural, [Kind]) Expand (TyF Ty)
+      StateT (Natural, Store MetaPtr Natural, [Kind]) Expand (TyF Ty)
     genVarsTyF vars (TyF ctor args) =
       TyF <$> genVarsCtor vars ctor
           <*> traverse (genTyVars vars) args
 
     genVarsCtor ::
       [MetaPtr] -> TypeConstructor ->
-      StateT (Natural, Map MetaPtr Natural, [Kind]) Expand TypeConstructor
+      StateT (Natural, Store MetaPtr Natural, [Kind]) Expand TypeConstructor
     genVarsCtor vars (TMetaVar v)
       | v `elem` vars = do
           (i, indices, argKinds) <- get
-          case Map.lookup v indices of
+          case St.lookup v indices of
             Nothing -> do
               k <- lift $ typeVarKind v
-              put (i + 1, Map.insert v i indices, argKinds ++ [k])
+              put (i + 1, St.insert v i indices, argKinds ++ [k])
               pure $ TSchemaVar i
             Just j -> pure $ TSchemaVar j
       | otherwise = pure $ TMetaVar v

--- a/src/Kind.hs
+++ b/src/Kind.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -9,11 +10,16 @@ module Kind (Kind(..), KindVar, newKindVar, kFun, KindStore) where
 
 import Control.Lens
 import Data.Data (Data)
-import Data.Map.Strict (Map)
 
 import Unique
 
-newtype KindVar = KindVar Unique deriving (Data, Eq, Ord)
+import Util.Store (Store)
+import Util.Key
+
+newtype KindVar = KindVar Unique
+  deriving newtype (Eq, Ord, HasKey)
+  deriving stock   Data
+
 
 instance Show KindVar where
   show (KindVar i) = "(KindVar " ++ show (hashUnique i) ++ ")"
@@ -33,8 +39,8 @@ newKindVar = KindVar <$> newUnique
 kFun :: [Kind] -> Kind -> Kind
 kFun args result = foldr KFun result args
 
-newtype KindStore = KindStore (Map KindVar Kind)
-  deriving (Monoid, Semigroup, Show)
+newtype KindStore = KindStore (Store KindVar Kind)
+  deriving newtype (Monoid, Semigroup, Show)
 
 type instance Index KindStore = KindVar
 type instance IxValue KindStore = Kind

--- a/src/KlisterPath.hs
+++ b/src/KlisterPath.hs
@@ -33,7 +33,7 @@ import Control.Lens (view)
 import Data.Functor ((<&>))
 import qualified Data.Set as Set
 import Data.Set (Set)
-import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Prettyprinter as PP
 import System.Directory (canonicalizePath, listDirectory)
 import System.FilePath (takeDirectory)
 import System.FilePath.Posix ((</>))

--- a/src/ModuleName.hs
+++ b/src/ModuleName.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 module ModuleName (
   -- * Module names
     ModuleName(..)
@@ -15,17 +17,23 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import System.Directory
 import System.FilePath
+import Data.Hashable
+import GHC.Generics (Generic)
 
 import ShortShow
 
 newtype KernelName = Kernel ()
-  deriving (Data, Eq, Ord, Show)
+  deriving (Data, Eq, Ord, Show, Generic)
+
+instance Hashable KernelName
 
 kernelName :: KernelName
 kernelName = Kernel ()
 
 data ModuleName = ModuleName FilePath | KernelName KernelName
-  deriving (Data, Eq, Ord, Show)
+  deriving (Data, Eq, Ord, Show, Generic)
+
+instance Hashable ModuleName
 
 instance ShortShow ModuleName where
   shortShow (ModuleName x) = x

--- a/src/Phase.hs
+++ b/src/Phase.hs
@@ -1,17 +1,29 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Phase (Phase, phaseNum, runtime, prior, Phased(..)) where
+module Phase (Phase(..), runtime, prior, Phased(..)) where
 
 import Control.Lens
 import Data.Data (Data)
+import Data.Sequence (Seq)
 import Numeric.Natural
 
 import ShortShow
 
+import Util.Key
+
 newtype Phase = Phase { phaseNum :: Natural }
-  deriving (Data, Eq, Ord, Show)
+  deriving newtype (Eq, Ord, Show, Num)
+  deriving stock Data
 makePrisms ''Phase
+
+instance HasKey Phase where
+  getKey (Phase n) = fromInteger $ toInteger n
+  fromKey i = Phase $! fromIntegral  i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
 
 instance ShortShow Phase where
   shortShow (Phase i) = "p" ++ show i
@@ -29,4 +41,7 @@ instance Phased Phase where
   shift j (Phase i) = Phase (i + j)
 
 instance Phased a => Phased [a] where
+  shift i = fmap (shift i)
+
+instance Phased a => Phased (Seq a) where
   shift i = fmap (shift i)

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -12,9 +12,9 @@ import Control.Lens hiding (List)
 import Control.Monad.State
 import qualified Data.HashMap.Strict as HM
 import qualified Util.Set as Set
-import Data.Text.Prettyprint.Doc hiding (Pretty(..), angles, parens)
-import qualified Data.Text.Prettyprint.Doc as PP
-import Data.Text.Prettyprint.Doc.Render.Text (putDoc, renderStrict)
+import Prettyprinter hiding (Pretty(..), angles, parens)
+import qualified Prettyprinter as PP
+import Prettyprinter.Render.Text (putDoc, renderStrict)
 import Data.Sequence (Seq)
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -10,13 +10,15 @@ module Pretty (Doc, Pretty(..), string, text, viaShow, (<+>), (<>), align, hang,
 
 import Control.Lens hiding (List)
 import Control.Monad.State
-import qualified Data.Map as Map
-import qualified Data.Set as Set
+import qualified Data.HashMap.Strict as HM
+import qualified Util.Set as Set
 import Data.Text.Prettyprint.Doc hiding (Pretty(..), angles, parens)
-import Data.Text (Text)
-import qualified Data.Text as T
 import qualified Data.Text.Prettyprint.Doc as PP
 import Data.Text.Prettyprint.Doc.Render.Text (putDoc, renderStrict)
+import Data.Sequence (Seq)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Foldable as F
 import System.FilePath (takeFileName)
 
 import Binding
@@ -38,6 +40,8 @@ import Type
 import Unique
 import Value
 import World
+
+import qualified Util.Store as St
 
 text :: Text -> Doc ann
 text = PP.pretty
@@ -284,7 +288,7 @@ instance Pretty VarInfo core => Pretty VarInfo (ScopedString core) where
 instance PrettyBinder VarInfo CompleteDecl where
   ppBind env (CompleteDecl d) = ppBind env d
 
-instance PrettyBinder VarInfo [CompleteDecl] where
+instance PrettyBinder VarInfo (Seq CompleteDecl) where
   ppBind env decls = over _1 vsep
                    $ foldr go (\e -> (mempty, e)) decls mempty
     where
@@ -294,7 +298,6 @@ instance PrettyBinder VarInfo [CompleteDecl] where
       go decl cc e = let (doc, e') = ppBind (env <> e) decl
                          (docs, e'') = cc (e <> e')
                      in (doc:docs, e'')
-
 
 instance Pretty VarInfo Kind where
   pp _   KStar        = text "*"
@@ -566,14 +569,14 @@ instance Pretty VarInfo a => Pretty VarInfo (World a) where
     vsep $ map (hang 4)
       [vsep [ text "Expanded modules"
             , vsep [ pp env m
-                   | (_, m) <- Map.toList (view worldModules w)
+                   | (_, m) <- HM.toList (view worldModules w)
                    ]
             ]
       , vsep [ text "Modules visited"
              , vsep [ hang 4 $
                       pp env mn <> line <>
                       text "{" <> group (vsep (map (pp env) ps)) <> text "}"
-                    | (mn, Set.toList -> ps) <- Map.toList (view worldVisited w)
+                    | (mn, Set.toList -> ps) <- HM.toList (view worldVisited w)
                     ]
              ]
       , vsep [ text "Environments"
@@ -581,7 +584,7 @@ instance Pretty VarInfo a => Pretty VarInfo (World a) where
                vsep [ hang 4 $
                       pp env p <> line <>
                       pp env rho
-                    | (p, rho) <- Map.toList $ view worldEnvironments w
+                    | (p, rho) <- St.toList $ view worldEnvironments w
                     ]
              ]
       ]
@@ -644,8 +647,8 @@ instance Pretty VarInfo BindingTable where
                       text "{" <> group (vsep [ pp env scs <+> text "↦" <+>
                                                 pp env b <+> text "@" <+>
                                                 pp env info
-                                              | (scs, b, info) <- xs]) <> text "}"
-                    | (n, xs) <- Map.toList $ view bindings bs
+                                              | (scs, b, info) <- F.toList xs]) <> text "}"
+                    | (n, xs) <- HM.toList $ view bindings bs
                     ]
 
 punc :: Doc VarInfo -> [Doc VarInfo] -> [Doc VarInfo]
@@ -666,7 +669,7 @@ instance Pretty VarInfo ScopeSet where
       ppSet s =
         text "{" <> commaSep (map (pp env) (Set.toList s)) <> text "}"
       ppMap m =
-        group (vsep [group (viaShow k <+> text "↦" <> line <> v) | (k, v) <- Map.toList m])
+        group (vsep [group (viaShow k <+> text "↦" <> line <> v) | (k, v) <- St.toList m])
 
 
 instance Pretty VarInfo KlisterPathError where

--- a/src/Scope.hs
+++ b/src/Scope.hs
@@ -1,14 +1,31 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Scope where
 
 import Data.Data (Data)
 import Control.Lens
 
+#ifdef KDEBUG
 import Data.Text (Text)
+#else
+import Util.Key
+#endif
+
 
 -- Int should be enough for now - consider bumping to something like int64
+#ifndef KDEBUG
+newtype Scope = Scope { scopeNum :: Int}
+  deriving newtype (Eq, Ord, Show, HasKey)
+  deriving stock Data
+#else
+-- For a debug build Scope keeps a blob of text for debugging the expander
+-- output. This will have an impact of the performance of the interpreter so it
+-- won't be useful for performance issues
 data Scope = Scope { scopeNum :: Int, scopePurpose :: Text }
   deriving (Data, Eq, Ord, Show)
+#endif
 makeLenses ''Scope
-

--- a/src/SplitCore.hs
+++ b/src/SplitCore.hs
@@ -26,7 +26,6 @@ module SplitCore where
 
 import Prelude hiding (lookup)
 import Control.Lens hiding (children)
-import Control.Monad.Except
 import Control.Monad.Writer
 
 import Core

--- a/src/SplitCore.hs
+++ b/src/SplitCore.hs
@@ -20,21 +20,30 @@ coalescing a 'SplitCore' expression into a fully-formed 'Core' expression.
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module SplitCore where
 
+import Prelude hiding (lookup)
 import Control.Lens hiding (children)
 import Control.Monad.Except
 import Control.Monad.Writer
-import Data.Map (Map)
-import qualified Data.Map as Map
 
 import Core
 import PartialCore
 import Unique
 
+import Util.Key
+import Util.Store
+
 newtype SplitCorePtr = SplitCorePtr Unique
-  deriving (Eq, Ord)
+  deriving newtype (Eq, Ord)
+
+instance HasKey SplitCorePtr where
+  getKey (SplitCorePtr u) = getKey u
+  fromKey i = SplitCorePtr $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
 
 instance Show SplitCorePtr where
   show (SplitCorePtr u) = "(SplitCorePtr " ++ show (hashUnique u) ++ ")"
@@ -45,6 +54,12 @@ newSplitCorePtr = SplitCorePtr <$> newUnique
 newtype PatternPtr = PatternPtr Unique
   deriving (Eq, Ord)
 
+instance HasKey PatternPtr where
+  getKey (PatternPtr u) = getKey u
+  fromKey i = PatternPtr $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
+
 instance Show PatternPtr where
   show (PatternPtr u) = "(PatternPtr " ++ show (hashUnique u) ++ ")"
 
@@ -54,18 +69,23 @@ newPatternPtr = PatternPtr <$> newUnique
 newtype TypePatternPtr = TypePatternPtr Unique
   deriving (Eq, Ord)
 
+instance HasKey TypePatternPtr where
+  getKey (TypePatternPtr u) = getKey u
+  fromKey i = TypePatternPtr $! fromKey i
+  {-# INLINE getKey  #-}
+  {-# INLINE fromKey #-}
+
 instance Show TypePatternPtr where
   show (TypePatternPtr u) = "(TypePatternPtr " ++ show (hashUnique u) ++ ")"
 
 newTypePatternPtr :: IO TypePatternPtr
 newTypePatternPtr = TypePatternPtr <$> newUnique
 
-
 data SplitCore = SplitCore
   { _splitCoreRoot         :: SplitCorePtr
-  , _splitCoreDescendants  :: Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr)
-  , _splitCorePatterns     :: Map PatternPtr (ConstructorPatternF PatternPtr)
-  , _splitCoreTypePatterns :: Map TypePatternPtr TypePattern
+  , _splitCoreDescendants  :: Store SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr)
+  , _splitCorePatterns     :: Store PatternPtr (ConstructorPatternF PatternPtr)
+  , _splitCoreTypePatterns :: Store TypePatternPtr TypePattern
   }
 makeLenses ''SplitCore
 
@@ -76,14 +96,14 @@ unsplit (SplitCore {..}) = PartialCore $ go _splitCoreRoot
       SplitCorePtr ->
       Maybe (CoreF (Maybe TypePattern) PartialPattern PartialCore)
     go ptr = do
-      this <- Map.lookup ptr _splitCoreDescendants
+      this <- lookup ptr _splitCoreDescendants
       return (mapCoreF tpat pat (PartialCore . go) this)
     pat :: PatternPtr -> PartialPattern
     pat ptr = PartialPattern $ do
-      this <- Map.lookup ptr _splitCorePatterns
+      this <- lookup ptr _splitCorePatterns
       return $ fmap pat this
     tpat :: TypePatternPtr -> Maybe TypePattern
-    tpat ptr = Map.lookup ptr _splitCoreTypePatterns
+    tpat ptr = lookup ptr _splitCoreTypePatterns
 
 
 split :: PartialCore -> IO SplitCore
@@ -95,15 +115,15 @@ split partialCore = do
     go ::
       SplitCorePtr ->
       Maybe (CoreF (Maybe TypePattern) PartialPattern PartialCore) ->
-      WriterT (Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
-               Map PatternPtr (ConstructorPatternF PatternPtr),
-               Map TypePatternPtr TypePattern)
+      WriterT (Store SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
+               Store PatternPtr (ConstructorPatternF PatternPtr),
+               Store TypePatternPtr TypePattern)
         IO
         ()
     go _     Nothing = pure ()
     go place (Just c) = do
       children <- traverseCoreF tpat pat subtree c
-      tell $ (Map.singleton place children, mempty, mempty)
+      tell (singleton place children, mempty, mempty)
 
     subtree p = do
       here <- liftIO newSplitCorePtr
@@ -113,28 +133,28 @@ split partialCore = do
     pat ::
       PartialPattern ->
       WriterT
-        (Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
-         Map PatternPtr (ConstructorPatternF PatternPtr),
-         Map TypePatternPtr TypePattern)
+        (Store SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
+         Store PatternPtr (ConstructorPatternF PatternPtr),
+         Store TypePatternPtr TypePattern)
         IO
         PatternPtr
     pat (PartialPattern Nothing) = liftIO newPatternPtr
     pat (PartialPattern (Just it)) = do
       here <- liftIO newPatternPtr
       layer <- traverse pat it
-      tell (mempty, Map.singleton here layer, mempty)
+      tell (mempty, singleton here layer, mempty)
       return here
 
     tpat ::
       Maybe TypePattern ->
       WriterT
-        (Map SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
-         Map PatternPtr (ConstructorPatternF PatternPtr),
-         Map TypePatternPtr TypePattern)
+        (Store SplitCorePtr (CoreF TypePatternPtr PatternPtr SplitCorePtr),
+         Store PatternPtr (ConstructorPatternF PatternPtr),
+         Store TypePatternPtr TypePattern)
         IO
         TypePatternPtr
     tpat Nothing = liftIO newTypePatternPtr
     tpat (Just it) = do
       here <- liftIO newTypePatternPtr
-      tell (mempty, mempty, Map.singleton here it)
+      tell (mempty, mempty, singleton here it)
       return here

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -7,14 +7,23 @@ code or from the expansion of user macros. It is transformed into Klister\'s
 core language by the expander.
 -}
 
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 
-module Syntax where
+module Syntax
+ ( addScope
+ , removeScope
+ , flipScope
+ , flipScope'
+ , addScope'
+ , removeScope'
+ , addScopes
+ , stxLoc
+ , syntaxE
+ , syntaxText
+ , module Syntax.Syntax
+ )where
 
 import Control.Lens hiding (List)
 import Data.Data (Data)
@@ -25,70 +34,10 @@ import Alpha
 import ModuleName
 import Phase
 import Scope
-import ScopeSet (ScopeSet)
+import ScopeSet
 import ShortShow
-import qualified ScopeSet
 import Syntax.SrcLoc
-
-data Stx a = Stx
-  { _stxScopeSet :: ScopeSet
-  , _stxSrcLoc   :: !SrcLoc
-  , _stxValue    :: a
-  }
-  deriving (Data, Eq, Functor, Show)
-makeLenses ''Stx
-
-data ExprF a
-  = Id Text
-  | String Text
-  | Integer Integer
-  | List [a]
-  deriving (Data, Eq, Functor, Show)
-makePrisms ''ExprF
-
-
-newtype Syntax = Syntax { _unSyntax :: (Stx (ExprF Syntax)) }
-  deriving (Data, Eq, Show)
-makeLenses ''Syntax
-
-type Ident = Stx Text
-
-data ParsedModule a = ParsedModule
-  { _moduleSource :: ModuleName
-  , _moduleLanguage :: a
-  , _moduleContents :: a
-  }
-  deriving (Eq, Show)
-makeLenses ''ParsedModule
-
-class HasScopes a where
-  getScopes :: a -> ScopeSet
-  adjustScope :: (Scope -> ScopeSet -> ScopeSet) -> Scope -> a -> a
-  mapScopes :: (ScopeSet -> ScopeSet) -> a -> a
-
-instance HasScopes (Stx Text) where
-  getScopes (Stx scs _ _) = scs
-  adjustScope f sc (Stx scs srcloc x) = Stx (f sc scs) srcloc x
-  mapScopes f (Stx scs srcloc x) = Stx (f scs) srcloc x
-
-instance HasScopes Syntax where
-  getScopes (Syntax (Stx scs _ _)) = scs
-  adjustScope f sc = mapScopes (f sc)
-  mapScopes f (Syntax (Stx scs srcloc e)) =
-    Syntax $
-    Stx (f scs) srcloc $
-    mapRec e
-    where
-      mapRec (Id x) = Id x
-      mapRec (String str) = String str
-      mapRec (Integer i) = Integer i
-      mapRec (List xs) = List $ map (\stx -> mapScopes f stx) xs
-
-instance Phased (Stx Text) where
-  shift i = mapScopes (shift i)
-
-instance Phased Syntax where
-  shift i = mapScopes (shift i)
+import Syntax.Syntax
 
 
 addScope :: HasScopes a => Phase -> Scope -> a -> a
@@ -113,25 +62,8 @@ addScope' = adjustScope ScopeSet.insertUniversally
 removeScope' :: HasScopes a => Scope -> a -> a
 removeScope' = adjustScope ScopeSet.deleteUniversally
 
-
-addScopes :: forall a. HasScopes a => ScopeSet -> a -> a
-addScopes scopeSet
-  = addSpecificScopes
-  . addUniversalScopes
-  where
-    addUniversalScopes :: HasScopes a => a -> a
-    addUniversalScopes a0 =
-      foldlOf (to ScopeSet.contents . _1 . folded)
-              (flip addScope')
-              a0
-              scopeSet
-
-    addSpecificScopes :: HasScopes a => a -> a
-    addSpecificScopes a0 =
-      ifoldlOf (to ScopeSet.contents .> _2 .> ifolded <. folded)
-               (\p a sc -> addScope p sc a)
-               a0
-               scopeSet
+addScopes :: HasScopes p => ScopeSet -> p -> p
+addScopes =  addScopes'
 
 stxLoc :: Syntax -> SrcLoc
 stxLoc (Syntax (Stx _ srcloc _)) = srcloc
@@ -146,38 +78,3 @@ syntaxText (Syntax (Stx _ _ e)) = go e
     go (String str) = T.pack $ show str
     go (Integer s) = T.pack (show s)
     go (List xs) = "(" <> T.intercalate " " (map syntaxText xs) <> ")"
-
-instance AlphaEq a => AlphaEq (Stx a) where
-  alphaCheck (Stx scopeSet1 srcLoc1 x1)
-             (Stx scopeSet2 srcLoc2 x2) = do
-    alphaCheck scopeSet1 scopeSet2
-    alphaCheck srcLoc1   srcLoc2
-    alphaCheck x1        x2
-
-instance AlphaEq a => AlphaEq (ExprF a) where
-  alphaCheck (Id x1)
-             (Id x2) = do
-    alphaCheck x1 x2
-  alphaCheck (List xs1)
-             (List xs2) = do
-    alphaCheck xs1 xs2
-  alphaCheck _ _ = notAlphaEquivalent
-
-instance AlphaEq Syntax where
-  alphaCheck (Syntax x1)
-             (Syntax x2) = do
-    alphaCheck x1 x2
-
-
-instance ShortShow a => ShortShow (Stx a) where
-  shortShow (Stx _ _ x) = shortShow x
-
-instance ShortShow a => ShortShow (ExprF a) where
-  shortShow (Id x) = shortShow x
-  shortShow (String s) = show s
-  shortShow (List xs) = shortShow xs
-  shortShow (Integer s) = show s
-
-instance ShortShow Syntax where
-  shortShow (Syntax x) = shortShow x
-

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -25,17 +25,12 @@ module Syntax
  , module Syntax.Syntax
  )where
 
-import Control.Lens hiding (List)
-import Data.Data (Data)
 import Data.Text (Text)
 import qualified Data.Text as T
 
-import Alpha
-import ModuleName
 import Phase
 import Scope
 import ScopeSet
-import ShortShow
 import Syntax.SrcLoc
 import Syntax.Syntax
 

--- a/src/Syntax/Syntax.hs
+++ b/src/Syntax/Syntax.hs
@@ -1,0 +1,149 @@
+-- | Internal module for Syntax component. Holds core data types, classes and
+-- smart constructors.
+
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Syntax.Syntax where
+
+import Control.Lens hiding (List)
+import Data.Data (Data)
+import Data.Text (Text)
+
+import Alpha
+import ModuleName
+import Phase
+import Scope
+import ScopeSet
+import ShortShow
+import Syntax.SrcLoc
+
+import qualified Util.Set   as Set
+import qualified Util.Store as St
+
+
+data Stx a = Stx
+  { _stxScopeSet :: ScopeSet
+  , _stxSrcLoc   :: !SrcLoc
+  , _stxValue    :: a
+  }
+  deriving (Data, Eq, Functor, Show)
+makeLenses ''Stx
+
+data ExprF a
+  = Id Text
+  | String Text
+  | Integer Integer
+  | List [a]
+  deriving (Data, Eq, Functor, Show)
+makePrisms ''ExprF
+
+
+newtype Syntax = Syntax { _unSyntax :: (Stx (ExprF Syntax)) }
+  deriving (Data, Eq, Show)
+makeLenses ''Syntax
+
+type Ident = Stx Text
+
+data ParsedModule a = ParsedModule
+  { _moduleSource :: ModuleName
+  , _moduleLanguage :: a
+  , _moduleContents :: a
+  }
+  deriving (Eq, Show)
+makeLenses ''ParsedModule
+
+class HasScopes a where
+  getScopes :: a -> ScopeSet
+  adjustScope :: (Scope -> ScopeSet -> ScopeSet) -> Scope -> a -> a
+  mapScopes :: (ScopeSet -> ScopeSet) -> a -> a
+
+instance HasScopes (Stx Text) where
+  getScopes (Stx scs _ _) = scs
+  adjustScope f sc (Stx scs srcloc x) = Stx (f sc scs) srcloc x
+  mapScopes f (Stx scs srcloc x) = Stx (f scs) srcloc x
+
+instance HasScopes Syntax where
+  getScopes (Syntax (Stx scs _ _)) = scs
+  adjustScope f sc = mapScopes (f sc)
+  mapScopes f (Syntax (Stx scs srcloc e)) =
+    Syntax $
+    Stx (f scs) srcloc $
+    mapRec e
+    where
+      mapRec (Id x) = Id x
+      mapRec (String str) = String str
+      mapRec (Integer i) = Integer i
+      mapRec (List xs) = List $ map (\stx -> mapScopes f stx) xs
+
+instance Phased (Stx Text) where
+  shift i = mapScopes (shift i)
+
+instance Phased Syntax where
+  shift i = mapScopes (shift i)
+
+instance AlphaEq a => AlphaEq (Stx a) where
+  alphaCheck (Stx scopeSet1 srcLoc1 x1)
+             (Stx scopeSet2 srcLoc2 x2) = do
+    alphaCheck scopeSet1 scopeSet2
+    alphaCheck srcLoc1   srcLoc2
+    alphaCheck x1        x2
+
+instance AlphaEq a => AlphaEq (ExprF a) where
+  alphaCheck (Id x1)
+             (Id x2) = do
+    alphaCheck x1 x2
+  alphaCheck (List xs1)
+             (List xs2) = do
+    alphaCheck xs1 xs2
+  alphaCheck _ _ = notAlphaEquivalent
+
+instance AlphaEq Syntax where
+  alphaCheck (Syntax x1)
+             (Syntax x2) = do
+    alphaCheck x1 x2
+
+
+instance ShortShow a => ShortShow (Stx a) where
+  shortShow (Stx _ _ x) = shortShow x
+
+instance ShortShow a => ShortShow (ExprF a) where
+  shortShow (Id x) = shortShow x
+  shortShow (String s) = show s
+  shortShow (List xs) = shortShow xs
+  shortShow (Integer s) = show s
+
+instance ShortShow Syntax where
+  shortShow (Syntax x) = shortShow x
+
+addScopes' :: HasScopes p => ScopeSet -> p -> p
+#ifndef KDEBUG
+addScopes' scopeSet =  mapScopes (over phaseScopes newSpecificScopes
+                                 . over universalScopes newUniversalScopes)
+  where
+    newUniversalScopes = Set.union (view _1 (contents scopeSet))
+    newSpecificScopes  = St.unionWith (<>) (view _2 (contents scopeSet))
+#else
+addScopes' scopeSet
+  = addSpecificScopes
+  . addUniversalScopes
+  where
+    addUniversalScopes :: HasScopes a => a -> a
+    addUniversalScopes a0 =
+      foldlOf (to ScopeSet.contents . _1 . folded)
+              (flip addScope')
+              a0
+              scopeSet
+
+    addSpecificScopes :: HasScopes a => a -> a
+    addSpecificScopes a0 =
+      ifoldlOf (to ScopeSet.contents .> _2 .> ifolded <. folded)
+               (\p a sc -> addScope p sc a)
+               a0
+               scopeSet
+#endif

--- a/src/Type.hs
+++ b/src/Type.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -14,7 +15,6 @@ import Control.Lens
 import Control.Monad
 import Data.Foldable
 import Data.Data (Data)
-import Data.Map (Map)
 import Numeric.Natural
 
 import Alpha
@@ -23,8 +23,12 @@ import Kind
 import ShortShow
 import Unique
 
+import Util.Key
+import Util.Store
+
 newtype MetaPtr = MetaPtr Unique
-  deriving (Data, Eq, Ord)
+  deriving newtype (Eq, Ord, HasKey)
+  deriving stock   Data
 
 newMetaPtr :: IO MetaPtr
 newMetaPtr = MetaPtr <$> newUnique
@@ -70,7 +74,7 @@ data TVar t = TVar
   deriving (Functor, Show)
 makeLenses ''TVar
 
-newtype TypeStore t = TypeStore (Map MetaPtr (TVar t))
+newtype TypeStore t = TypeStore (Store MetaPtr (TVar t))
   deriving (Functor, Monoid, Semigroup, Show)
 
 type instance Index (TypeStore t) = MetaPtr

--- a/src/Type/Context.hs
+++ b/src/Type/Context.hs
@@ -3,20 +3,21 @@
 module Type.Context where
 
 import Control.Lens
-import Data.Map (Map)
-import qualified Data.Map as Map
 
 import Env
 import Phase
 
-newtype TypeContext v t = TypeContext (Map Phase (Env v t))
+import Util.Store (Store)
+import qualified Util.Store as St
+
+newtype TypeContext v t = TypeContext (Store Phase (Env v t))
   deriving Show
 
 instance Ord v => Semigroup (TypeContext v t) where
-  TypeContext γ1 <> TypeContext γ2 = TypeContext (Map.unionWith (<>) γ1 γ2)
+  TypeContext γ1 <> TypeContext γ2 = TypeContext (St.unionWith (<>) γ1 γ2)
 
 instance Ord v => Monoid (TypeContext v t) where
-  mempty = TypeContext Map.empty
+  mempty = TypeContext mempty
 
 type instance Index (TypeContext v a) = Phase
 type instance IxValue (TypeContext v a) = Env v a
@@ -28,4 +29,4 @@ instance Ord v => At (TypeContext v a) where
   at x f (TypeContext env) = TypeContext <$> at x f env
 
 instance Phased (TypeContext v t) where
-  shift i (TypeContext γ) = TypeContext (Map.mapKeys (shift i) γ)
+  shift i (TypeContext γ) = TypeContext (St.mapKeys (shift i) γ)

--- a/src/Util/Key.hs
+++ b/src/Util/Key.hs
@@ -1,0 +1,13 @@
+-- | Tiny module to wrap operations for IntMaps
+
+module Util.Key
+  (HasKey(..)
+  ) where
+
+class HasKey a where
+  getKey :: a -> Int
+  fromKey :: Int -> a
+
+instance HasKey Int where
+  getKey  = id
+  fromKey = id

--- a/src/Util/Set.hs
+++ b/src/Util/Set.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE RoleAnnotations    #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | wrapper over IntSet for our purposes
+
+module Util.Set
+  (
+#ifndef KDEBUG
+    member
+  , singleton
+  , empty
+  , size
+  , isSubsetOf
+  , insert
+  , delete
+  , toList
+  , fromList
+  , Set
+  , union
+#else
+  module Data.Set
+#endif
+  )
+where
+
+import Prelude hiding (lookup)
+import Control.Lens
+import Data.Data (Data)
+import Data.Functor
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IS
+import Control.Monad (guard)
+import Util.Key
+
+#ifdef KDEBUG
+import Data.Set
+#endif
+
+newtype Set key = Set { unSet :: IntSet}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+  deriving stock   Data
+type role Set nominal
+
+type instance IxValue (Set p) = ()
+type instance Index   (Set p) = p
+
+instance HasKey p => Ixed (Set p) where
+  ix k f m = if member k m
+    then f () $> m
+    else pure m
+
+instance HasKey p => At (Set p) where
+    {-# INLINE at #-}
+    at k f s = fmap choose (f (guard member_))
+      where
+      member_ = member k s
+
+      (inserted, deleted)
+        | member_   = (s, delete k s)
+        | otherwise = (insert k s, s)
+
+      choose (Just ~()) = inserted
+      choose Nothing    = deleted
+
+member :: HasKey e => e -> Set e -> Bool
+member e s = IS.member (getKey e) (unSet s)
+
+empty :: Set e
+empty = Set IS.empty
+
+size :: Set e -> Int
+size = IS.size . unSet
+
+singleton :: HasKey e => e -> Set e
+singleton = Set . IS.singleton . getKey
+
+insert :: HasKey e => e -> Set e -> Set e
+insert e s = Set $! IS.insert (getKey e) (unSet s)
+
+delete :: HasKey e => e -> Set e -> Set e
+delete e s = Set $! IS.delete (getKey e) (unSet s)
+
+isSubsetOf :: Set e -> Set e -> Bool
+isSubsetOf l r = IS.isSubsetOf (unSet l) (unSet r)
+
+toList :: HasKey p => Set p -> [p]
+toList = map fromKey . IS.toList . unSet
+
+fromList :: HasKey p => [p] -> Set p
+fromList = Set . IS.fromList . map getKey
+
+union :: Set p -> Set p -> Set p
+union l r = Set $! IS.union (unSet l) (unSet r)

--- a/src/Util/Store.hs
+++ b/src/Util/Store.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE RoleAnnotations    #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | wrapper over IntMap for our purposes
+
+module Util.Store
+  ( lookup
+  , singleton
+  , insert
+  , toList
+  , fromList
+  , Store
+  , unionWith
+  , mapKeys
+  , mapMaybeWithKey
+  )
+where
+
+import Prelude hiding (lookup)
+import Control.Lens
+import Data.Data (Data)
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IM
+import Control.Arrow (first)
+
+import Util.Key
+import Phase
+
+newtype Store p v = Store { unStore :: IntMap v}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid, Functor, Foldable)
+  deriving stock   Data
+type role Store nominal _
+
+instance Traversable (Store p) where
+  traverse f s = Store <$> traverse f (unStore s)
+
+instance  FoldableWithIndex Phase (Store p) where
+    ifoldMap f s = IM.foldMapWithKey (f . Phase . fromIntegral  . toInteger) (unStore s)
+    {-# INLINE ifoldMap #-}
+    ifoldr f acc s = IM.foldrWithKey (f . Phase . fromIntegral  . toInteger) acc (unStore s)
+    {-# INLINE ifoldr #-}
+    ifoldl' f acc s = IM.foldlWithKey' (\e k ac -> f (fromIntegral k) e ac) acc (unStore s)
+    {-# INLINE ifoldl' #-}
+
+type instance IxValue (Store p v) = v
+type instance Index   (Store p v) = p
+
+instance HasKey p => Ixed (Store p v) where
+  ix k f m = case lookup k m of
+    Just v -> f v <&> \new_v -> insert k new_v m
+    Nothing -> pure m
+
+instance HasKey p => At (Store p v) where
+  at k f s = alterF f k s
+  {-# INLINE at #-}
+
+instance (c ~ d) => Each (Store c a) (Store d b) a b where
+  each = traversed
+
+lookup :: HasKey p => p -> Store p v -> Maybe v
+lookup ptr graph = getKey ptr `IM.lookup` unStore graph
+
+singleton :: HasKey p => p -> v -> Store p v
+singleton ptr val = Store $! IM.singleton (getKey ptr) val
+
+insert :: HasKey p => p -> v -> Store p v -> Store p v
+insert k v str = Store $! IM.insert (getKey k) v (unStore str)
+
+toList :: HasKey p => Store p v -> [(p,v)]
+toList str = map (first fromKey) $ IM.toList (unStore str)
+
+fromList :: HasKey p => [(p,v)] -> Store p v
+fromList ps = Store $! IM.fromList $ map (first getKey) ps
+
+alterF :: ( Functor f, HasKey p)
+       => (Maybe v -> f (Maybe v)) -> p -> Store p v -> f (Store p v)
+alterF f k s = Store <$> IM.alterF f (getKey k) (unStore s)
+
+unionWith :: (v -> v -> v) -> Store p v -> Store p v -> Store p v
+unionWith f l r = Store $! IM.unionWith f (unStore l) (unStore r)
+
+mapMaybeWithKey :: HasKey p => (p -> a -> Maybe b) -> Store p a -> Store p b
+mapMaybeWithKey f s = Store $! IM.mapMaybeWithKey (f . fromKey) (unStore s)
+
+mapKeys :: HasKey p => (p -> p) -> Store p v -> Store p v
+mapKeys f s = Store $! IM.mapKeys (getKey . f . fromKey) (unStore s)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
-resolver: lts-14.8
+resolver: lts-20.25
 packages:
 - .
 extra-deps:
-  - unordered-containers-0.2.19.1@sha256:9ad8972c2e913c37b1d4f0e1261517fd7a1b8c8a58077e057be69837e3dbaa00,3822
+  - transformers-0.6.1.0@sha256:7e7feea5fc9071375a973a48290fee6664e3eba38eb7028ce04850911f1ad0d4,3146
+  - mtl-2.3.1
+  - exceptions-0.10.7
+  - hedgehog-1.2
+  - tasty-hedgehog-1.4.0.0@sha256:d29ba1e363d9d41da5b34d4f320ab761cbc9c19fda6091d2d650351604c2d9aa,1795

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-14.8
 packages:
 - .
-extra-deps: []
+extra-deps:
+  - unordered-containers-0.2.19.1@sha256:9ad8972c2e913c37b1d4f0e1261517fd7a1b8c8a58077e057be69837e3dbaa00,3822

--- a/tests/Golden.hs
+++ b/tests/Golden.hs
@@ -9,7 +9,8 @@ module Golden where
 
 import Control.Lens hiding (argument)
 import Control.Monad.Catch (bracket)
-import Control.Monad.Except
+import Control.Monad
+import Control.Monad.IO.Class
 import Control.Monad.Trans.Writer (WriterT, execWriterT, tell)
 import Data.Foldable (for_)
 import Data.Text.Lazy (Text)

--- a/tests/Golden.hs
+++ b/tests/Golden.hs
@@ -17,7 +17,7 @@ import qualified Data.Text.Lazy as T
 import System.FilePath (replaceExtension, takeBaseName)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Golden (findByExtension, goldenVsStringDiff)
-import qualified Data.Map as Map
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Lazy as Text
 import qualified Data.Text.Lazy.Encoding as TE
 import System.IO (Handle, openFile, hClose, IOMode(WriteMode))
@@ -64,7 +64,7 @@ runExamples file = do
 
       -- a normal test so all good
       Right (moduleName, result) ->
-        case Map.lookup moduleName (view worldEvaluated (view expanderWorld result)) of
+        case HM.lookup moduleName (view worldEvaluated (view expanderWorld result)) of
           Nothing      -> fail "Internal error: module not evaluated"
           Just results -> do
             -- Show just the results of evaluation in the module the user

--- a/tests/MiniTests.hs
+++ b/tests/MiniTests.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Tiny module to hold mini-test strings. Some mini-test strings are split
+-- strings which conflict with the CPP pragma. See
+-- https://downloads.haskell.org/ghc/latest/docs/users_guide/phases.html#cpp-and-string-gaps
+
+module MiniTests where
+
+import Data.Text
+
+trivialUserMacro :: Text
+trivialUserMacro = "[let-syntax \n\
+                   \  [m [lambda [_] \n\
+                   \       [pure [quote [lambda [x] x]]]]] \n\
+                   \  m]"
+
+letMacro :: Text
+letMacro = "[let-syntax \n\
+            \  [let1 [lambda [stx] \n\
+            \          (syntax-case stx \n\
+            \            [[list [_ binder body]] \n\
+            \             (syntax-case binder \n\
+            \               [[list [x e]] \n\
+            \                {- [[lambda [x] body] e] -} \n\
+            \                [pure [list-syntax \n\
+            \                        [[list-syntax \n\
+            \                           [[ident-syntax 'lambda stx] \n\
+            \                            [list-syntax [x] stx] \n\
+            \                            body] \n\
+            \                           stx] \n\
+            \                         e] \n\
+            \                        stx]]])])]] \n\
+            \  [let1 [x [lambda [x] x]] \n\
+            \    x]]"
+
+unboundVarLet :: Text
+unboundVarLet = "[let-syntax \
+                \  [m [lambda [_] \
+                \       [pure [quote [lambda [x] x]]]]] \
+                \  anyRandomWord]"


### PR DESCRIPTION
Hey David and Sam,

I've made a few performance tweaks in the expander. The overall result is that the testsuite now runs in about 10 seconds instead of 38 seconds and `implicit-conversion-test` finishes in 1 second compared to 10 seconds.

I wrote a case study on it for my book here: https://input-output-hk.github.io/hs-opt-handbook.github.io/src/Case_Studies/klister.html

please review it at your leisure. @david-christiansen I tried to request a review on github but that unfortunately requires you to be part of the IOG organization, so I went ahead and merged it. I've re-opened the IT ticket to move the book.

Please do not merge this before I squash. I like to keep a clean commit history.