### PR TITLE
execute macro actions in phase 1

### DIFF
--- a/src/Expander.hs
+++ b/src/Expander.hs
@@ -1306,7 +1306,7 @@ expandOneForm prob stx
                           ValueSyntax $ addScope p stepScope stx
               case macroVal of
                 ValueMacroAction act -> do
-                  res <- interpretMacroAction prob act
+                  res <- inEarlierPhase $ interpretMacroAction prob act
                   case res of
                     StuckOnType loc ty env cases kont ->
                       forkAwaitingTypeCase loc prob ty env cases kont
@@ -1432,8 +1432,8 @@ interpretMacroAction prob =
         getIdent (ValueSyntax stx) = mustBeIdent stx
         getIdent _other = throwError $ InternalError $ "Not a syntax object in " ++ opName
         compareFree id1 id2 = do
-          b1 <- resolve id1
-          b2 <- resolve id2
+          b1 <- inLaterPhase $ resolve id1
+          b2 <- inLaterPhase $ resolve id2
           return $ Done $
             flip primitiveCtor [] $
             if b1 == b2 then "true" else "false"

--- a/src/Expander/Monad.hs
+++ b/src/Expander/Monad.hs
@@ -45,6 +45,7 @@ module Expander.Monad
   , getDecl
   , getState
   , inEarlierPhase
+  , inLaterPhase
   , inPhase
   , isExprChecked
   , importing
@@ -406,6 +407,10 @@ inPhase p act = Expand $ local (over (expanderLocal . expanderPhase) (const p)) 
 inEarlierPhase :: Expand a -> Expand a
 inEarlierPhase act =
   Expand $ local (over (expanderLocal . expanderPhase) prior) $ runExpand act
+
+inLaterPhase :: Expand a -> Expand a
+inLaterPhase act =
+  Expand $ local (over (expanderLocal . expanderPhase) posterior) $ runExpand act
 
 moduleScope :: ModuleName -> Expand Scope
 moduleScope mn = moduleScope' mn

--- a/src/Phase.hs
+++ b/src/Phase.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Phase (Phase(..), runtime, prior, Phased(..)) where
+module Phase (Phase(..), runtime, prior, posterior, Phased(..)) where
 
 import Control.Lens
 import Data.Data (Data)
@@ -33,6 +33,9 @@ runtime = Phase 0
 
 prior :: Phase -> Phase
 prior (Phase i) = Phase (i + 1)
+
+posterior :: Phase -> Phase
+posterior (Phase i) = Phase (i - 1)
 
 class Phased a where
   shift :: Natural -> a -> a


### PR DESCRIPTION
As discussed [here](https://github.com/gelisam/klister/pull/new/gelisam/in-later-phase), if `my-macro` is a user-defined macro whose `(-> Syntax (Macro Syntax))` is `myMacroImpl` and `(my-macro)`  is encountered at phase 0, then the current code will evaluate `(myMacroImpl '(my-macro))` at phase 1 but will execute the resulting `(Macro Syntax)` at phase 0. This seems wrong to me, I think it should also execute at phase 1.

I have changed the code so that the `(Macro Syntax)` is also executed at phase 1. The only consequence of this change which was found by the test suite was to break `free-identifier=?`. Consider this code:
```
(define my-keyword ...)
(define-macros
  ([my-macro
    (lambda (stx)
      (case (open-syntax stx)
        [(list-contents (list _ x))
         (>>= (free-identifier=? x 'my-keyword)
           ...)]))]))
```

When the `(free-identifier=? x 'my-keyword)` action is executed, then the current implementation will look up "my-keyword" and "my-keyword" in the current phase (previously phase 0, now phase 1) and determine whether they point to the same binding. In phase 0, they do point to the same binding, so `free-identifier=?` return true, but at phase 1 there is no binding for "my-keyword", so `free-identifier=?` returns false.

Now, we do want `free-identifier=?` to return true, so I have changed `free-identifier=?` so that instead of looking up "my-keyword" in the _current_ phase (now phase 1), it now looks it up in phase 0, thus resolving the issue. This change makes sense to me: if e.g. the macro had a local variable named "my-keyword", we would not want `x` to resolve to that local variable, we still want `x` to resolve to the top-level `define`. So `free-identifier=?` should look up the variables in the environment of the macro's call site, not in the current environment.

Does this make sense? Did I find and fix a bug, or is my intuition completely wrong?