### PR TITLE
project: deprecate 8.10.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
             ghc: "9.2.5"
             os: ubuntu-latest
 
-          - cabal: "3.2"
-            ghc: "8.10.7"
-            os: ubuntu-latest
-
             # latest GHC, non-default OS
           - cabal: "3.8"
             ghc: "9.6"
@@ -106,8 +102,8 @@ jobs:
 
     - name: Build
       run: |
-        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+        stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --no-nix
 
     - name: Test
       run: |
-        stack test --system-ghc
+        stack test --system-ghc --no-nix

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711401922,
-        "narHash": "sha256-QoQqXoj8ClGo0sqD/qWKFWezgEwUL0SUh37/vY2jNhc=",
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07262b18b97000d16a4bdb003418bd2fb067a932",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,36 +1,57 @@
 {
-  description = "A Klister flake";
-
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  description = "A klister flake";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs    = nixpkgs.legacyPackages.${system};
-        overlay = final: prev: {
-          klister = prev.callCabal2nix "klister" ./. { };
-        };
-        haskellPackages = pkgs.haskellPackages.extend overlay;
-      in {
-        # nix build
-        packages.default = haskellPackages.klister;
+        pkgs = nixpkgs.legacyPackages.${system};
 
-        # nix develop
-        devShells.default = haskellPackages.shellFor {
-          withHoogle = true;
-          packages = p: [ p.klister ];
-          buildInputs = with haskellPackages; [
-            cabal-install
-            haskell-language-server
-            eventlog2html
-          ];
-          shellHook = ''
-            export KLISTERPATH="$(pwd)"/examples/
+        hPkgs =
+          pkgs.haskell.packages."ghc966"; # need to match Stackage LTS version
+                                           # from stack.yaml snapshot
+
+        myDevTools = [
+          hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)
+          hPkgs.ghcid # Continuous terminal Haskell compile checker
+          hPkgs.ormolu # Haskell formatter
+          hPkgs.hlint # Haskell codestyle checker
+          hPkgs.hoogle # Lookup Haskell documentation
+          hPkgs.haskell-language-server # LSP server for editor
+          hPkgs.implicit-hie # auto generate LSP hie.yaml file from cabal
+          hPkgs.retrie # Haskell refactoring tool
+          # hPkgs.cabal-install
+          stack-wrapped
+          pkgs.zlib # External C library needed by some Haskell packages
+        ];
+
+        # Wrap Stack to work with our Nix integration. We don't want to modify
+        # stack.yaml so non-Nix users don't notice anything.
+        # - no-nix: We don't want Stack's way of integrating Nix.
+        # --system-ghc    # Use the existing GHC on PATH (will come from this Nix file)
+        # --no-install-ghc  # Don't try to install GHC if no matching GHC found on PATH
+        stack-wrapped = pkgs.symlinkJoin {
+          name = "stack"; # will be available as the usual `stack` in terminal
+          paths = [ pkgs.stack ];
+          buildInputs = [ pkgs.makeWrapper ];
+          postBuild = ''
+            wrapProgram $out/bin/stack \
+              --add-flags "\
+                --no-nix \
+                --system-ghc \
+                --no-install-ghc \
+              "
           '';
         };
-      }
-    );
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = myDevTools;
+
+          # Make external Nix c libraries like zlib known to GHC, like
+          # pkgs.haskell.lib.buildStackProject does
+          # https://github.com/NixOS/nixpkgs/blob/d64780ea0e22b5f61cd6012a456869c702a72f20/pkgs/development/haskell-modules/generic-stack-builder.nix#L38
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath myDevTools;
+        };
+      });
 }

--- a/klister.cabal
+++ b/klister.cabal
@@ -8,7 +8,7 @@ author:         David Christiansen <david@davidchristiansen.dk>,  Samuel Géline
 maintainer:     David Christiansen <david@davidchristiansen.dk>,  Samuel Gélineau <gelisam@gmail.com>
 license:        BSD-3-Clause
 license-file:   LICENSE
-tested-with:    GHC==8.10.7, GHC==9.2.5, GHC==9.4, GHC==9.6
+tested-with:    GHC==9.2.5, GHC==9.4, GHC==9.6
 build-type:     Simple
 data-files:
     stdlib/defun.kl

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,8 @@
-resolver: lts-20.25
+resolver: lts-22.39
 packages:
 - .
 extra-deps:
-  - transformers-0.6.1.0@sha256:7e7feea5fc9071375a973a48290fee6664e3eba38eb7028ce04850911f1ad0d4,3146
-  - mtl-2.3.1
-  - exceptions-0.10.7
-  - hedgehog-1.2
-  - tasty-hedgehog-1.4.0.0@sha256:d29ba1e363d9d41da5b34d4f320ab761cbc9c19fda6091d2d650351604c2d9aa,1795
+
+# mark nix as disable. Nix users can use cabal and the nix flake
+nix:
+  enable: false


### PR DESCRIPTION
Made the nix flake work with stack. This bumps the stack lts. I built with both stack and cabal and it seemed fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated development environment for Haskell with new tools and libraries.
	- Introduced a new section in the configuration to enable Nix support.

- **Bug Fixes**
	- Removed outdated GHC version from compatibility testing.

- **Chores**
	- Updated resolver version in configuration for improved dependency management.
	- Cleaned up unnecessary dependencies from the project configuration.
	- Streamlined Continuous Integration process by removing outdated job configurations.
	- Adjusted build and test commands in CI to enhance performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->