### PR TITLE
document algebraic datatypes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,7 @@ Features we borrow from ML:
 * A type system with parametric polymorphism, `algebraic datatypes`_, and
   Hindley-Milner type inference.
 
-.. _algebraic datatypes: TODO: write a small example defining and matching on
-   an algebraic type. Perhaps Either? Let's also take the opportunity to
-   demonstrate polymorphic functions on Either.
+.. _algebraic datatypes: examples/either-datatype.kl
 
 Features we borrow from Haskell:
 

--- a/examples/either-datatype.golden
+++ b/examples/either-datatype.golden
@@ -1,0 +1,6 @@
+#<closure> : ∀(α : *) (β : *) (γ : *). ((α → β) → ((γ → β) → ((Either α γ) → β)))
+#<closure> : ((Either Integer String) → String)
+"42" : String
+#<closure> : ∀(α : *) (β : *) (γ : *). ((Either α (Either β γ)) → (Either γ (Either α β)))
+(:: 42 (nil)) : (List Integer)
+1 : Integer

--- a/examples/either-datatype.kl
+++ b/examples/either-datatype.kl
@@ -1,7 +1,6 @@
 #lang "prelude.kl"
 
 (import (shift "prelude.kl" 1))
-(import (shift "list.kl" 1))
 (import "define-syntax-rule.kl")
 (import "list.kl")
 

--- a/examples/either-datatype.kl
+++ b/examples/either-datatype.kl
@@ -1,7 +1,128 @@
 #lang "prelude.kl"
 
+(import (shift "prelude.kl" 1))
+(import (shift "list.kl" 1))
+(import "define-syntax-rule.kl")
+(import "list.kl")
+
+
+-- A sum type, like in Haskell:
+--
+-- > data Either a b
+-- >   = Left a
+-- >   | Right b
+--
+-- Note Klister's naming convention: type-level names (including type
+-- variables!) are Uppercase, while value-level names (including data
+-- constructors!) are lowercase.
 (datatype (Either A B)
   (left A)
   (right B))
 
-(export Either left right)
+-- Pattern-matching, like in Haskell:
+--
+-- > case either of
+-- >   Left x -> onLeft x
+-- >   Right y -> onRight y
+--
+-- Since Klister is a typed language, it is a compile-time error if the type of
+-- the pattern does not match the type of the scrutinee (try [(true) (true)]).
+-- Klister does not yet emit a warning if the patterns are not exhaustive (try
+-- deleting the [(right _) (false)]).
+--
+(defun run-either (on-left on-right either)
+  (case either
+    [(left x)
+     (on-left x)]
+    [(right y)
+     (on-right y)]))
+
+-- look at "either-datatype.golden" to see that the inferred type is
+-- > run-either
+-- >   : ∀ (A : *) (B : *) (R : *)
+-- >   . (A → R)
+-- >   → (B → R)
+-- >   → (Either A B)
+-- >   → R
+(example run-either)
+
+-- _ : Either Integer String → String
+(example (run-either integer->string id))
+
+-- "42"
+(example (run-either integer->string id (left 42)))
+
+
+-- Next, let's define a variant of Either with three cases: leftmost, center,
+-- and rightmost.
+--
+-- The most straightforward way to do it would be to define a new datatype with
+-- three data constructors, but let's take this opportunity to demonstrate the
+-- Klister equivalent of Haskell's type synonyms and pattern synonyms.
+--
+-- In Klister, macro invocations are also expanded inside types and patterns.
+-- Therefore, to define a type synonym or a pattern synonym, it suffices to
+-- define a macro.
+
+-- > type Ternary a b c  = Either a (Either b c)
+-- > pattern Leftmost  x = Left x
+-- > pattern Center    y = Right (Left y)
+-- > pattern Rightmost z = Right (Right z)
+(define-syntax-rule (Ternary A B C)  (Either A (Either B C)))
+(define-syntax-rule (leftmost x)     (left x))
+(define-syntax-rule (center y)       (right (left y)))
+(define-syntax-rule (rightmost z)    (right (right z)))
+
+(defun run-ternary (on-leftmost on-center on-rightmost ternary)
+  (case ternary
+    [(leftmost x)
+     (on-leftmost x)]
+    [(center y)
+     (on-center y)]
+    [(rightmost z)
+     (on-rightmost z)]))
+
+-- _ : ∀ (A : *) (B : *) (R : *)A
+--   . Ternary A B C
+--   → Ternary C A B
+(example (run-ternary
+           (lambda (x) (center x))
+           (lambda (y) (rightmost y))
+           (lambda (z) (leftmost z))))
+
+
+-- Haskell would say that we have defined "implicit bidirectional pattern
+-- synonyms", in the sense that they can appear in a pattern or an expression,
+-- and that they expand to the same thing in both locations.
+--
+-- It is also possible to define an "explicitly bidirectional pattern synonym",
+-- that is, a synonym which expands in a different way depending on whether it
+-- is used as a pattern or an expression.
+
+-- > pattern Head :: a -> [a]
+-- > pattern Head x <- x : _ where
+-- >   Head x = x : []
+(define-macro (head x)
+  (>>= (which-problem)
+    (lambda (problem)
+      (case problem
+        [(pattern)
+         -- called as (head x) in a pattern,
+         -- expand to (:: x _)
+         (pure `(:: ,x _))]
+        [(expression _)
+         -- called as (head x) in an expression,
+         -- expand to (:: x (nil))
+         (pure `(:: ,x (nil)))]))))
+
+-- (list 42)
+(example (head 42))
+
+-- 1
+(example (case (list 1 2 3)
+           [(head x)
+            x]))
+
+
+(export Either left right run-either
+        Ternary leftmost center rightmost run-ternary)

--- a/examples/either-datatype.kl
+++ b/examples/either-datatype.kl
@@ -25,9 +25,9 @@
 -- >   Right y -> onRight y
 --
 -- Since Klister is a typed language, it is a compile-time error if the type of
--- the pattern does not match the type of the scrutinee (try [(true) (true)]).
+-- the pattern does not match the type of the scrutinee (try [(true) (error 'undefined)]).
 -- Klister does not yet emit a warning if the patterns are not exhaustive (try
--- deleting the [(right _) (false)]).
+-- deleting the [(left x) (on-left x)]).
 --
 (defun run-either (on-left on-right either)
   (case either
@@ -81,7 +81,7 @@
     [(rightmost z)
      (on-rightmost z)]))
 
--- _ : ∀ (A : *) (B : *) (R : *)A
+-- _ : ∀ (A : *) (B : *) (R : *)
 --   . Ternary A B C
 --   → Ternary C A B
 (example (run-ternary
@@ -114,7 +114,7 @@
          -- expand to (:: x (nil))
          (pure `(:: ,x (nil)))]))))
 
--- (list 42)
+-- (:: 42 (nil))
 (example (head 42))
 
 -- 1


### PR DESCRIPTION
I gave [Google Jules](https://jules.google.com) the prompt

> Pick a ticket with the Easy label and implement it

and it chose to implement a TODO from the README instead. I was not quite happy with [its solution](https://github.com/gelisam/klister/commit/50a95dabb6a16cd74dee025a48683c240faf8d08), but it did have the net benefit of motivating me to do it myself!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive example demonstrating sum types, pattern matching, type and pattern synonyms, and bidirectional pattern macros.
  - Introduced new functions and macros for working with `Either` types and a ternary variant, including `run-either`, `Ternary`, `leftmost`, `center`, `rightmost`, and `run-ternary`.

- **Documentation**
  - Updated the documentation to reference the new example file for algebraic datatypes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->